### PR TITLE
Need to use set_fact instead of register to track whether a package has been installed.

### DIFF
--- a/tasks/fs-default.yml
+++ b/tasks/fs-default.yml
@@ -2,30 +2,36 @@
 - name: Stat the final device file
   include_tasks: stat_device.yml
 
-- name: Install xfsprogs for xfs file system type
-  package:
-    name: xfsprogs
-    state: present
-  register: xfsprogs_installed
+- block:
+  - name: Install xfsprogs for xfs file system type
+    package:
+      name: xfsprogs
+      state: present
+  - set_fact:
+      xfsprogs_installed: true
   when: "volume.fs_type == 'xfs' and ['xfsprogs'] is not subset(ansible_facts.packages.keys()) \
          and xfsprogs_installed is undefined and not ansible_check_mode \
          and ((pool is defined and pool.state in 'present') or volume.state in 'present')"
 
-- name: Install e2fsprogs for ext file system type
-  package:
-    name: e2fsprogs
-    state: present
-  register: e2fsprogs_installed
+- block:
+  - name: Install e2fsprogs for ext file system type
+    package:
+      name: e2fsprogs
+      state: present
+  - set_fact:
+      e2fsprogs_installed: true
   when: "volume.fs_type in ['ext2', 'ext3', 'ext4'] and \
          ['e2fsprogs'] is not subset(ansible_facts.packages.keys()) and \
          e2fsprogs_installed is undefined and not ansible_check_mode \
          and ((pool is defined and pool.state in 'present') or volume.state in 'present')"
 
-- name: Install util-linux as needed
-  package:
-    name: util-linux
-    state: present
-  register: util_linux_installed
+- block:
+  - name: Install util-linux as needed
+    package:
+      name: util-linux
+      state: present
+  - set_fact:
+      util_linux_installed: true
   when: "(volume.fs_type == 'swap' or volume.state == 'absent' or
          (pool is defined and pool.state is defined and pool.state == 'absent'))
          and ['util-linux'] is not subset(ansible_facts.packages.keys()) and

--- a/tasks/pool-partition-default.yml
+++ b/tasks/pool-partition-default.yml
@@ -1,9 +1,11 @@
 ---
-- name: Install parted for partition management
-  package:
-    name: parted
-    state: present
-  register: parted_installed
+- block:
+  - name: Install parted for partition management
+    package:
+      name: parted
+      state: present
+  - set_fact:
+      parted_installed: true
   # update this condition when current use_partitions issue (#5) is fixed.
   when: "use_partitions and ['parted'] is not subset(ansible_facts.packages.keys()) \
          and parted_installed is undefined and not ansible_check_mode"


### PR DESCRIPTION
* This was found when running a playbook where the first role instantiation created an lvm group with xfs, and the second role just changed the fs_type to ext4. The playbook would fail as the system didn't have the mkfs.ext4 executable. This means that `e2fsprogs` task was skipped in the second run-through as the registered variable `e2fsprogs_installed` was interpreted as being defined in the previous role run-through despite being skipped initially.

### Playbook used:
```yaml
---
- hosts: localhost
  become: true
  vars:

  roles:
    - name: storage
      storage_pools:
        - name: foo
          disks: ['vdc']
          volumes:
            - name: test1
              size: 10g
              fs_type: 'xfs'
              mount_point: '/opt/test1'

    - name: storage
      storage_pools:
        - name: foo
          disks: ['vdc']
          volumes:
            - name: test1
              size: 10g
              fs_type: 'ext4'
              mount_point: '/opt/test1'
```