### PR TITLE
syntax error with ansible 2.6

### DIFF
--- a/tasks/volume-default.yml
+++ b/tasks/volume-default.yml
@@ -73,7 +73,7 @@
   when: volume._preexist
 
 - set_fact:
-    volume: "{{ volume|combine({'_orig_mount_point': ansible_facts.mounts|selectattr('device', 'eq', volume._device)|map(attribute='mount')|list|first|default('')}, recursive=True) }}"
+    volume: "{{ volume|combine({'_orig_mount_point': ansible_facts.mounts|selectattr('device', 'equalto', volume._device)|map(attribute='mount')|list|first|default('')}, recursive=True) }}"
 
 - set_fact:
     volume: "{{ volume|combine({'_wipe': volume._preexist and (not volume.fs_type or (volume._orig_fs_type and volume.fs_type != volume._orig_fs_type))}) }}"


### PR DESCRIPTION
When running this role with ansible 2.6 an error is thrown "unknow operand". changing eq to equalto fixes the problem
