### PR TITLE
Fix removal of filesystem on every run for non-LVM volumes

### DIFF
--- a/tasks/volume-default.yml
+++ b/tasks/volume-default.yml
@@ -79,7 +79,7 @@
     volume: "{{ volume|combine({'_wipe': volume._preexist and (not volume.fs_type or (volume._orig_fs_type and volume.fs_type != volume._orig_fs_type))}) }}"
 
 - set_fact:
-    volume: "{{ volume|combine({'_remove': volume.state == 'absent' or (pool is not defined or (pool.state is defined and pool.state == 'absent'))}) }}"
+    volume: "{{ volume|combine({'_remove': volume.state == 'absent' or (pool is defined and pool.state is defined and pool.state == 'absent')}) }}"
 
 - set_fact:
     volume: "{{ volume|combine({'_create': volume.state == 'present' and (pool is not defined or (pool.state is not defined or pool.state == 'present'))}) }}"


### PR DESCRIPTION
Currently, `volume._remove` always comes back as `true` when working with non-LVM volumes. This is because `pool` being undefined will always make the conditional true.

I assume that the intended behavior is for a volume to be removed when either is is configured as absent or it's parent pool is absent.

I've only tested this with my use-case of managing partitions without LVM, but this *shouldn't* break anything there.