### PR TITLE
Verify that disk volumes are mounted by UUID in fstab

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ The `mount_point` specifies the directory on which the file system will be mount
 ##### `mount_options`
 The `mount_options` specifies custom mount options as a string, e.g.: 'ro'.
 
+##### `encryption`
+This specifies whether or not the volume will be encrypted using LUKS.
+__WARNING__: Toggling encryption for a volume is a destructive operation, meaning
+             all data on that volume will be removed as part of the process of
+             adding/removing the encryption layer.
+
+##### `encryption_passphrase`
+This string specifies a passphrase used to unlock/open the LUKS volume.
+
+##### `encryption_key_file`
+This string specifies the full path to the key file used to unlock the LUKS volume.
+
+##### `encryption_cipher`
+This string specifies a non-default cipher to be used by LUKS.
+
+##### `encryption_key_size`
+This integer specifies the LUKS key size (in bytes).
+
+##### `encryption_luks_version`
+This integer specifies the LUKS version to use.
+
 #### `storage_safe_mode`
 When true (the default), an error will occur instead of automatically removing existing devices and/or formatting.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,10 @@ storage_volume_defaults:
   mount_check: 0
   mount_passno: 0
   mount_device_identifier: "uuid"  # uuid|label|path
+
+  encryption: false
+  encryption_passphrase: null
+  encryption_key_file: null
+  encryption_cipher: null
+  encryption_key_size: null
+  encryption_luks_version: null

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -311,7 +311,7 @@ class BlivetVolume(object):
         if safe_mode and (self._device.format.type is not None or self._device.format.name != get_format(None).name):
             raise BlivetAnsibleError("cannot remove existing formatting on volume '%s' in safe mode" % self._volume['name'])
 
-        if self._device.format.status:
+        if self._device.format.status and (self._device.format.mountable or self._device.format.type == "swap"):
             self._device.format.teardown()
         self._blivet.format_device(self._device, fmt)
 
@@ -934,7 +934,8 @@ def run_module():
     result['packages'] = b.packages[:]
 
     for action in scheduled:
-        if action.is_destroy and action.is_format and action.format.exists:
+        if action.is_destroy and action.is_format and action.format.exists and \
+           (action.format.mountable or action.format.type == "swap"):
             action.format.teardown()
 
     if scheduled:

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -357,6 +357,9 @@ class BlivetDiskVolume(BlivetVolume):
     def _type_check(self):
         return self._device.raw_device.is_disk
 
+    def _create(self):
+        self._reformat()
+
     def _look_up_device(self):
         super(BlivetDiskVolume, self)._look_up_device()
         if not self._get_device_id():

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -190,6 +190,20 @@ class BlivetVolume(object):
         if device is None:
             return
 
+        if device.format.type == 'luks':
+            # XXX If we have no key we will always re-encrypt.
+            device.format._key_file = self._volume.get('encryption_key_file')
+            device.format.passphrase = self._volume.get('encryption_passphrase')
+
+            # set up the original format as well since it'll get used for processing
+            device.original_format._key_file = self._volume.get('encryption_key_file')
+            device.original_format.passphrase = self._volume.get('encryption_passphrase')
+            if device.isleaf:
+                self._blivet.populate()
+
+            if not device.isleaf:
+                device = device.children[0]
+
         self._device = device
 
         # check that the type is correct, raising an exception if there is a name conflict

--- a/molecule_extra_requirements.txt
+++ b/molecule_extra_requirements.txt
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: MIT
 
 # Write extra requirements for running molecule here:
+jmespath

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -166,6 +166,19 @@
   when: blivet_output['mounts']
 
 #
+# Manage /etc/crypttab
+#
+- name: Manage /etc/crypttab to account for changes we just made
+  crypttab:
+    name: "{{ entry.name }}"
+    backing_device: "{{ entry.backing_device }}"
+    password: "{{ entry.password }}"
+    state: "{{ entry.state }}"
+  loop: "{{ blivet_output.crypts }}"
+  loop_control:
+    loop_var: entry
+
+#
 # Update facts since we may have changed system state.
 #
 # Should this be in a handler instead?

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -129,14 +129,34 @@
 #  changed options? (just add w/ new settings?)
 # add new mounts
 #
-- name: manage mounts to match the specified state
+# XXX Apparently we have to do the removals, then tell systemd to
+#     update its view, then set up the new mounts. Otherwise,
+#     systemd will forcibly prevent mounting a new volume to an
+#     existing mount point.
+- name: remove obsolete mounts
   mount:
     src: "{{ mount_info['src']|default(omit) }}"
     path: "{{ mount_info['path'] }}"
     fstype: "{{ mount_info['fstype']|default(omit) }}"
     opts: "{{ mount_info['opts']|default(omit) }}"
     state: "{{ mount_info['state'] }}"
-  loop: "{{ blivet_output.mounts }}"
+  loop: "{{ blivet_output.mounts|json_query('[?state==`absent`]') }}"
+  loop_control:
+    loop_var: mount_info
+
+- name: tell systemd to refresh its view of /etc/fstab
+  systemd:
+    daemon_reload: yes
+  when: blivet_output['mounts']
+
+- name: set up new/current mounts
+  mount:
+    src: "{{ mount_info['src']|default(omit) }}"
+    path: "{{ mount_info['path'] }}"
+    fstype: "{{ mount_info['fstype']|default(omit) }}"
+    opts: "{{ mount_info['opts']|default(omit) }}"
+    state: "{{ mount_info['state'] }}"
+  loop: "{{ blivet_output.mounts|json_query('[?state!=`absent`]') }}"
   loop_control:
     loop_var: mount_info
 

--- a/tests/test-verify-volume-device.yml
+++ b/tests/test-verify-volume-device.yml
@@ -2,7 +2,7 @@
 # name/path
 - name: See whether the device node is present
   stat:
-    path: "{{ storage_test_volume._device }}"
+    path: "{{ storage_test_volume._raw_device }}"
     follow: yes
   register: storage_test_dev
 
@@ -16,13 +16,13 @@
 
 - name: Make sure we got info about this volume
   assert:
-    that: "{{ storage_test_volume._device in storage_test_blkinfo.info }}"
+    that: "{{ storage_test_volume._raw_device in storage_test_blkinfo.info }}"
     msg: "Failed to gather info about volume '{{ storage_test_volume.name }}'"
   when: _storage_test_volume_present
 
 - name: Verify the volume's device type
   assert:
-    that: "{{ storage_test_blkinfo.info[storage_test_volume._device].type == storage_test_volume.type }}"
+    that: "{{ storage_test_blkinfo.info[storage_test_volume._raw_device].type == storage_test_volume.type }}"
   when: _storage_test_volume_present
 
 # disks

--- a/tests/test-verify-volume-encryption.yml
+++ b/tests/test-verify-volume-encryption.yml
@@ -1,0 +1,35 @@
+---
+# name/path
+- name: Stat the LUKS device, if encrypted
+  stat:
+    path: "{{ storage_test_volume._device }}"
+    follow: yes
+  register: storage_test_luks_dev
+  when: storage_test_volume.encryption
+
+- name: Verify the presence/absence of the LUKS device node
+  assert:
+    that: "{{ storage_test_luks_dev.stat.exists and storage_test_luks_dev.stat.isblk
+              if _storage_test_volume_present or storage_test_volume.type == 'disk'
+              else
+              not storage_test_luks_dev.stat.exists }}"
+    msg: "Incorrect device node presence for volume {{ storage_test_volume.name }}"
+  when: storage_test_volume.encryption
+
+- name: Verify that the raw device is the same as the device if not encrypted
+  assert:
+    that: "{{ (storage_test_volume._device != storage_test_volume._raw_device)|bool == (storage_test_volume.encryption|bool) }}"
+    msg: "Encryption not managed correctly for volume {{ storage_test_volume.name }}: {{ (storage_test_volume._device != storage_test_volume._raw_device) }}  {{ storage_test_volume.encryption|bool }}"
+  when: _storage_test_volume_present
+
+- name: Make sure we got info about the LUKS volume if encrypted
+  assert:
+    that: "{{ storage_test_volume._device in storage_test_blkinfo.info }}"
+    msg: "Failed to gather info about volume '{{ storage_test_volume.name }}'"
+  when: _storage_test_volume_present and storage_test_volume.encryption
+
+- name: Verify the LUKS volume's device type if encrypted
+  assert:
+    that: "{{ storage_test_blkinfo.info[storage_test_volume._device].type == 'crypt' }}"
+  when: _storage_test_volume_present and storage_test_volume.encryption
+

--- a/tests/test-verify-volume-encryption.yml
+++ b/tests/test-verify-volume-encryption.yml
@@ -33,3 +33,35 @@
     that: "{{ storage_test_blkinfo.info[storage_test_volume._device].type == 'crypt' }}"
   when: _storage_test_volume_present and storage_test_volume.encryption
 
+- set_fact:
+    _storage_test_expected_crypttab_entries: "{{ (storage_test_volume.encryption and _storage_test_volume_present)|ternary(1, 0) }}"
+    _storage_test_crypttab_entries: "{{ storage_test_crypttab.stdout_lines|map('regex_search', '^' + storage_test_volume._device|basename + ' .*$')|select('string')|list }}"
+    _storage_test_expected_crypttab_key_file: "{{ storage_test_volume.encryption_key_file or '-' }}"
+
+- name: Check for /etc/crypttab entry
+  assert:
+    that: "{{ _storage_test_crypttab_entries|length == _storage_test_expected_crypttab_entries|int }}"
+    msg: "Incorrect number of crypttab entries found for volume {{ storage_test_volume.name }}"
+
+- name: Validate the format of the crypttab entry
+  assert:
+    that: "{{ _storage_test_crypttab_entries[0].split()|length >= 3 }}"
+    msg: "Incorrectly formatted crypttab line for volume {{ storage_test_volume.name }}"
+  when: _storage_test_expected_crypttab_entries|int == 1
+
+- name: Check backing device of crypttab entry
+  assert:
+    that: "{{ _storage_test_crypttab_entries[0].split()[1] == storage_test_volume._raw_device }}"
+    msg: "Incorrect backing device in crypttab entry for volume {{ storage_test_volume.name }}"
+  when: _storage_test_expected_crypttab_entries|int == 1
+
+- name: Check key file of crypttab entry
+  assert:
+    that: "{{ _storage_test_crypttab_entries[0].split()[2] == _storage_test_expected_crypttab_key_file }}"
+    msg: "Incorrect key file in crypttab entry for volume {{ storage_test_volume.name }}"
+  when: _storage_test_expected_crypttab_entries|int == 1
+
+- set_fact:
+    _storage_test_expected_crypttab_entries: null
+    _storage_test_crypttab_entries: null
+    _storage_test_expected_crypttab_key_file: null

--- a/tests/test-verify-volume.yml
+++ b/tests/test-verify-volume.yml
@@ -1,9 +1,8 @@
 ---
 - set_fact:
-    _storage_volume_tests: ['mount', 'fstab', 'fs', 'device'] # fs: type, label  device: name, size, type, disks
+    _storage_volume_tests: ['mount', 'fstab', 'fs', 'device', 'encryption'] # fs: type, label  device: name, size, type, disks
   # future:
   #   device:
-  #     encryption
   #     raid
   #     compression
   #     deduplication

--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -6,7 +6,7 @@
     mount_location: '/opt/test'
     volume_size: '5g'
     fs_type_after: "{{ 'ext3' if (ansible_distribution == 'RedHat' and ansible_distribution_major_version == '6') else 'ext4' }}"
-
+    pat: "{{ '^([^#\\s]+)\\s+' + mount_location + '\\s.*' }}"
   tasks:
     - include_role:
         name: storage
@@ -26,6 +26,23 @@
             mount_point: "{{ mount_location }}"
             disks: "{{ unused_disks }}"
 
+    - name: Load fstab
+      command: cat /etc/fstab
+      changed_when: false
+      check_mode: no
+      register: _test_change_disk_fs_fstab1
+
+    - name: print fstab device
+      debug:
+        msg: "device is: {{ ( _test_change_disk_fs_fstab1.stdout_lines|select('search', pat)
+        | map('regex_replace', pat, '\\1') | list )[0] }}"
+
+    - name: verify that we mount by UUID
+      assert:
+        that: "{{ _test_change_disk_fs_fstab1.stdout_lines|select('search', pat)
+        | map('regex_replace', pat, '\\1') | select('match', 'UUID=')
+      | list | length > 0 }}"
+
     - include_tasks: verify-role-results.yml
 
     - name: Change the disk device file system type to "{{ fs_type_after }}"
@@ -39,6 +56,23 @@
             fs_type: "{{ fs_type_after }}"
             disks: "{{ unused_disks }}"
 
+    - name: Load fstab
+      command: cat /etc/fstab
+      changed_when: false
+      check_mode: no
+      register: _test_change_disk_fs_fstab2
+
+    - name: print fstab device
+      debug:
+        msg: "device is: {{ (_test_change_disk_fs_fstab2.stdout_lines|select('search', pat)
+        | map('regex_replace', pat, '\\1') | list)[0] }}"
+
+    - name: verify that we mount by UUID
+      assert:
+        that: "{{_test_change_disk_fs_fstab2.stdout_lines|select('search', pat)
+        | map('regex_replace', pat, '\\1') | select('match', 'UUID=')
+      | list | length > 0 }}"
+
     - include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -51,6 +85,23 @@
             mount_point: "{{ mount_location }}"
             fs_type: "{{ fs_type_after }}"
             disks: "{{ unused_disks }}"
+
+    - name: Load fstab
+      command: cat /etc/fstab
+      changed_when: false
+      check_mode: no
+      register: _test_change_disk_fs_fstab3
+
+    - name: print fstab device
+      debug:
+        msg: "device is: {{ (_test_change_disk_fs_fstab3.stdout_lines|select('search', pat)
+        | map('regex_replace', pat, '\\1') | list)[0] }}"
+
+    - name: verify that we mount by UUID
+      assert:
+        that: "{{ _test_change_disk_fs_fstab3.stdout_lines|select('search', pat)
+        | map('regex_replace', pat, '\\1') | select('match', 'UUID=' )
+      | list | length > 0 }}"
 
     - include_tasks: verify-role-results.yml
 

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -1,0 +1,287 @@
+---
+- hosts: all
+  become: true
+  vars:
+    storage_safe_mode: false
+    mount_location: '/opt/test1'
+    volume_size: '5g'
+
+  tasks:
+    - include_role:
+        name: storage
+
+    - include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "{{ volume_size }}"
+        max_return: 1
+
+    ##
+    ## Disk
+    ##
+    - name: Test for correct handling of new encrypted volume w/ no key
+      block:
+        - name: Create an encrypted disk volume w/ default fs
+          include_role:
+            name: storage
+          vars:
+            storage_volumes:
+              - name: foo
+                type: disk
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                encryption: true
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the keyless luks test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('encrypted volume.*missing key') and
+                   not blivet_output.changed"
+            msg: "Unexpected behavior w/ encrypted pool w/ no key"
+
+    # encrypted disk volume
+    - name: Create an encrypted disk volume w/ default fs
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: foo
+            type: disk
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+            encryption: true
+            encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the encryption layer
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: foo
+            type: disk
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+            encryption: false
+            encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Add encryption to the volume
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: foo
+            type: disk
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+            encryption: true
+            encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    ##
+    ## Partition
+    ##
+
+    - name: Test for correct handling of new encrypted volume w/ no key
+      block:
+        - name: Create an encrypted partition volume w/ default fs
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: partition
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    type: partition
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+                    encryption: true
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the keyless luks test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('encrypted volume.*missing key') and
+                   not blivet_output.changed"
+            msg: "Unexpected behavior w/ encrypted pool w/ no key"
+
+    - name: Create an encrypted partition volume w/ default fs
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: partition
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                type: partition
+                mount_point: "{{ mount_location }}"
+                size: 4g
+                encryption: true
+                encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the encryption layer
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: partition
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                type: partition
+                mount_point: "{{ mount_location }}"
+                size: 4g
+                encryption: false
+                encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Add encryption to the volume
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: partition
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                type: partition
+                mount_point: "{{ mount_location }}"
+                size: 4g
+                encryption: true
+                encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    ##
+    ## LVM
+    ##
+
+    - name: Test for correct handling of new encrypted volume w/ no key
+      block:
+        - name: Create an encrypted lvm volume w/ default fs
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+                    encryption: true
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the keyless luks test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('encrypted volume.*missing key') and
+                   not blivet_output.changed"
+            msg: "Unexpected behavior w/ encrypted pool w/ no key"
+
+    - name: Create an encrypted lvm volume w/ default fs
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                mount_point: "{{ mount_location }}"
+                size: 4g
+                encryption: true
+                encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the encryption layer
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                mount_point: "{{ mount_location }}"
+                size: 4g
+                encryption: false
+                encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Add encryption to the volume
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                mount_point: "{{ mount_location }}"
+                size: 4g
+                encryption: true
+                encryption_passphrase: 'yabbadabbadoo'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Clean up
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: foo
+            type: disk
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - include_tasks: verify-role-results.yml

--- a/tests/verify-role-results.yml
+++ b/tests/verify-role-results.yml
@@ -21,6 +21,11 @@
   register: storage_test_fstab
   changed_when: false
 
+- name: Read the /etc/crypttab file
+  command: cat /etc/crypttab
+  register: storage_test_crypttab
+  changed_when: false
+
 #
 # Verify pools and the volumes they contain.
 #
@@ -51,5 +56,6 @@
 - name: Clean up variable namespace
   set_fact:
     storage_test_fstab: null
+    storage_test_crypttab: null
     storage_test_blkinfo: null
     storage_test_volume: null

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -1,6 +1,7 @@
 blivet_package_list:
   - python-enum34
   - python-blivet3
+  - libblockdev-crypto
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-swap

--- a/vars/CentOS-8.yml
+++ b/vars/CentOS-8.yml
@@ -1,5 +1,6 @@
 blivet_package_list:
   - python3-blivet
+  - libblockdev-crypto
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-swap

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,5 +1,6 @@
 blivet_package_list:
   - python3-blivet
+  - libblockdev-crypto
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-swap

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,6 +1,7 @@
 blivet_package_list:
   - python-enum34
   - python-blivet3
+  - libblockdev-crypto
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-swap

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,5 +1,6 @@
 blivet_package_list:
   - python3-blivet
+  - libblockdev-crypto
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-swap


### PR DESCRIPTION
Note that disk volumes mean filesystems directly on disks.

Currently the test fails: on first invocation the filesystem gets mounted by device name and only on the second by UUID. This should be also caught by a real idempotence test.

XXX this should be part of the existing verification task lists: there is already a task called "Verify that the device identifier appears in /etc/fstab", but it does not check for this condition.