### PR TITLE
Make all classes new-style (derive from object)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The `mount_point` specifies the directory on which the file system will be mount
 ##### `mount_options`
 The `mount_options` specifies custom mount options as a string, e.g.: 'ro'.
 
+#### `storage_safe_mode`
+When true (the default), an error will occur instead of automatically removing existing devices and/or formatting.
+
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 storage_provider: "blivet"
 storage_use_partitions: null
 storage_disklabel_type: null  # leave unset to allow the role to select an appropriate label type
+storage_safe_mode: false  # do not remove devices as needed to make space for new volumes
 
 storage_pool_defaults:
   state: "present"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 storage_provider: "blivet"
 storage_use_partitions: null
 storage_disklabel_type: null  # leave unset to allow the role to select an appropriate label type
-storage_safe_mode: false  # do not remove devices as needed to make space for new volumes
+storage_safe_mode: false  # fail instead of implicitly/automatically removing devices or formatting
 
 storage_pool_defaults:
   state: "present"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 storage_provider: "blivet"
 storage_use_partitions: null
 storage_disklabel_type: null  # leave unset to allow the role to select an appropriate label type
-storage_safe_mode: false  # fail instead of implicitly/automatically removing devices or formatting
+storage_safe_mode: true  # fail instead of implicitly/automatically removing devices or formatting
 
 storage_pool_defaults:
   state: "present"

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -127,7 +127,7 @@ class BlivetAnsibleError(Exception):
     pass
 
 
-class BlivetVolume:
+class BlivetVolume(object):
     def __init__(self, blivet_obj, volume, bpool=None):
         self._blivet = blivet_obj
         self._volume = volume
@@ -369,7 +369,7 @@ def _get_blivet_volume(blivet_obj, volume, bpool=None):
     return _BLIVET_VOLUME_TYPES[volume_type](blivet_obj, volume, bpool=bpool)
 
 
-class BlivetPool:
+class BlivetPool(object):
     def __init__(self, blivet_obj, pool):
         self._blivet = blivet_obj
         self._pool = pool
@@ -583,7 +583,7 @@ def manage_pool(b, pool):
         volume['_mount_id'] = bvolume._volume.get('_mount_id', '')
 
 
-class FSTab:
+class FSTab(object):
     def __init__(self, blivet_obj):
         self._blivet = blivet_obj
         self._entries = list()

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -519,7 +519,7 @@ class BlivetPartitionPool(BlivetPool):
             if not safe_mode:
                 self._blivet.devicetree.recursive_remove(self._device, remove_device=False)
             else:
-                raise BlivetAnsibleError("cannot remove existing formatting and/or devices on disk '%s' (pool '%s') in safe mode" % (disk.name, self._pool['name']))
+                raise BlivetAnsibleError("cannot remove existing formatting and/or devices on disk '%s' (pool '%s') in safe mode" % (self._device.name, self._pool['name']))
 
             label = get_format("disklabel", device=self._device.path, label_type=disklabel_type)
             self._blivet.format_device(self._device, label)

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -218,7 +218,7 @@ class BlivetVolume:
         if self._device.format.type == fmt.type:
             return
 
-        if safe_mode and self._device.format.type is None and self._device.format.name != get_format(None).name:
+        if safe_mode and (self._device.format.type is not None or self._device.format.name != get_format(None).name):
             raise BlivetAnsibleError("cannot remove existing formatting on volume '%s' in safe mode" % self._volume['name'])
 
         if self._device.format.status:

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -265,6 +265,19 @@ class BlivetDiskVolume(BlivetVolume):
     def _type_check(self):
         return self._device.is_disk
 
+    def _look_up_device(self):
+        super(BlivetDiskVolume, self)._look_up_device()
+        if not self._get_device_id():
+            # FAIL: no disks specified for volume
+            raise BlivetAnsibleError("no disks specified for volume '%s'" % self._volume['name'])  # sure about this one?
+        elif not isinstance(self._volume['disks'], list):
+            raise BlivetAnsibleError("volume disks must be specified as a list")
+
+        if self._device is None:
+            # FAIL: failed to find the disk
+            raise BlivetAnsibleError("unable to resolve disk specified for volume '%s' (%s)" % (self._volume['name'], self._volume['disks']))
+
+
 
 class BlivetPartitionVolume(BlivetVolume):
     def _type_check(self):

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -218,7 +218,7 @@ class BlivetVolume:
         if self._device.format.type == fmt.type:
             return
 
-        if safe_mode:
+        if safe_mode and self._device.format.type is None and self._device.format.name != get_format(None).name:
             raise BlivetAnsibleError("cannot remove existing formatting on volume '%s' in safe mode" % self._volume['name'])
 
         if self._device.format.status:

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -197,9 +197,6 @@ class BlivetVolume:
             raise BlivetAnsibleError("invalid size specification for volume '%s': '%s'" % (self._volume['name'], self._volume['size']))
 
         if size and self._device.resizable and self._device.size != size:
-            if safe_mode:
-                raise BlivetAnsibleError("cannot resize existing volume '%s' in safe mode" % self._volume['name'])
-
             if self._device.format.resizable:
                 self._device.format.update_size_info()
 

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -33,7 +33,7 @@ options:
             - disklabel type string (eg: 'gpt') to use, overriding the built-in logic in blivet
     safe_mode:
         description:
-            - boolean indicating that existing devices and file system should never be removed
+            - boolean indicating that we should fail rather than implicitly/automatically removing devices or formatting
 
 author:
     - David Lehman (dlehman@redhat.com)

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -537,7 +537,7 @@ class BlivetLVMPool(BlivetPool):
 
 
 _BLIVET_POOL_TYPES = {
-    "disk": BlivetPartitionPool,
+    "partition": BlivetPartitionPool,
     "lvm": BlivetLVMPool
 }
 

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -120,6 +120,7 @@ if BLIVET_PACKAGE:
 use_partitions = None  # create partitions on pool backing device disks?
 disklabel_type = None  # user-specified disklabel type
 safe_mode = None       # do not remove any existing devices or formatting
+packages_only = None   # only set things up enough to get a list of required packages
 
 
 class BlivetAnsibleError(Exception):
@@ -214,6 +215,8 @@ class BlivetVolume:
 
     def _reformat(self):
         """ Schedule actions as needed to ensure the volume is formatted as specified. """
+        global packages_only
+
         fmt = self._get_format()
         if self._device.format.type == fmt.type:
             return
@@ -221,7 +224,7 @@ class BlivetVolume:
         if safe_mode and (self._device.format.type is not None or self._device.format.name != get_format(None).name):
             raise BlivetAnsibleError("cannot remove existing formatting on volume '%s' in safe mode" % self._volume['name'])
 
-        if self._device.format.status:
+        if self._device.format.status and not packages_only:
             self._device.format.teardown()
         self._blivet.format_device(self._device, fmt)
 
@@ -708,6 +711,9 @@ def run_module():
 
     global safe_mode
     safe_mode = module.params['safe_mode']
+
+    global packages_only
+    packages_only = module.params['packages_only']
 
     b = Blivet()
     b.reset()

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -706,6 +706,9 @@ def run_module():
     global use_partitions
     use_partitions = module.params['use_partitions']
 
+    global safe_mode
+    safe_mode = module.params['safe_mode']
+
     b = Blivet()
     b.reset()
     fstab = FSTab(b)

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -38,7 +38,7 @@
     _storage_vols_no_defaults: "{{ _storage_vols_no_defaults|default([]) }} + [{{ item.1 }}]"
     _storage_vol_defaults: "{{ _storage_vol_defaults|default([]) }} + [{{ storage_volume_defaults }}]"
     _storage_vol_pools: "{{ _storage_vol_pools|default([]) }} + ['{{ item.0.name }}']"
-  loop: "{{ _storage_pools|subelements('volumes') }}"
+  loop: "{{ _storage_pools|subelements('volumes', skip_missing=true) }}"
   when: storage_pools is defined
 
 - name: Apply defaults to pools and volumes [3/6]

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -105,6 +105,7 @@
     volumes: "{{ _storage_volumes }}"
     use_partitions: "{{ storage_use_partitions }}"
     disklabel_type: "{{ storage_disklabel_type }}"
+    safe_mode: "{{ storage_safe_mode }}"
   register: blivet_output
 
 - debug:

--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: true
   vars:
+    storage_safe_mode: false
     mount_location: '/opt/test'
     volume_size: '5g'
     fs_type_after: "{{ 'ext3' if (ansible_distribution == 'RedHat' and ansible_distribution_major_version == '6') else 'ext4' }}"

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: true
   vars:
+    storage_safe_mode: false
     mount_location: '/opt/test1'
     volume_size: '5g'
     fs_after: "{{ (ansible_distribution == 'RedHat' and ansible_distribution_major_version == '6') | ternary('ext4', 'xfs') }}"

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: true
   vars:
+    storage_safe_mode: false
     storage_use_partitions: true
     mount_location: '/opt/test1'
     volume_size: '5g'

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: true
   vars:
+    storage_safe_mode: false
     mount_location: '/opt/test1'
 
   tasks:

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: true
   vars:
+    storage_safe_mode: false
     mount_location1: '/opt/test1'
     mount_location2: '/opt/test2'
     volume_group_size: '10g'

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: true
   vars:
+    storage_safe_mode: false
     mount_location: '/opt/test1'
 
   tasks:

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -19,7 +19,7 @@
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
-            type: disk
+            type: partition
             disks: "{{ unused_disks }}"
             volumes:
               - name: test1
@@ -34,7 +34,7 @@
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
-            type: disk
+            type: partition
             disks: "{{ unused_disks }}"
             volumes:
               - name: test1
@@ -49,7 +49,7 @@
       vars:
         storage_pools:
           - name:  "{{ unused_disks[0] }}"
-            type: disk
+            type: partition
             disks: "{{ unused_disks }}"
             state: absent
             volumes:
@@ -66,7 +66,7 @@
       vars:
         storage_pools:
           - name:  "{{ unused_disks[0] }}"
-            type: disk
+            type: partition
             disks: "{{ unused_disks }}"
             state: absent
             volumes:

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -114,7 +114,7 @@
 
     - name: Test for correct handling of safe_mode
       block:
-        - name: Try to create a LVM pool on the disk already containing a file system in safe_mode
+        - name: Try to create a partition pool on the disk already containing a file system in safe_mode
           include_role:
             name: storage
           vars:
@@ -156,7 +156,7 @@
           stat_r.stat.isreg is defined and stat_r.stat.isreg
         msg: "data lost!"
 
-    - name: Create a LVM pool on the disk already containing a file system w/o safe_mode
+    - name: Create a partition pool on the disk already containing a file system w/o safe_mode
       include_role:
         name: storage
       vars:
@@ -169,7 +169,7 @@
     - name: Verify the output
       assert:
         that: not blivet_output.failed
-        msg: "failed to create LVM pool over existing file system using default value of safe_mode"
+        msg: "failed to create partition pool over existing file system using default value of safe_mode"
 
     - name: Clean up
       include_role:

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -5,6 +5,14 @@
     mount_location: '/opt/test1'
 
   tasks:
+    - include_role:
+        name: storage
+
+    - include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "10g"
+        max_return: 1
+
     - name: Verify that the play fails with the expected error message
       block:
         - name: Create a disk volume mounted at "{{ mount_location }}"
@@ -21,4 +29,77 @@
           assert:
             that: "{{ blivet_output.failed }}"
             msg: "Expected error message not found for missing disk"
+      ignore_errors: yes
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Create a file system on disk
+          include_role:
+            name: storage
+          vars:
+            storage_volumes:
+              - name: test1
+                type: disk
+                fs_type: 'ext4'
+                disks: "{{ unused_disks }}"
+
+        - name: Try to replace the file system on disk in safe mode
+          include_role:
+            name: storage
+          vars:
+            storage_safe_mode: true
+            storage_volumes:
+              - name: test1
+                type: disk
+                fs_type: 'ext3'
+                disks: "{{ unused_disks }}"
+
+        - name: Verify the output
+          assert:
+            that: "{{ blivet_output.failed and
+                      blivet_output.msg|regex_search('cannot remove existing formatting on volume.*in safe mode') and
+                      not blivet_output.changed }}"
+            msg: "Unexpected behavior w/ existing data on specified disks"
+
+        - name: Try to create a partition pool on the disk already containing a file system in safe_mode
+          include_role:
+            name: storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: partition
+
+        - name: Verify the output
+          assert:
+            that: "{{ blivet_output.failed and
+                      blivet_output.msg|regex_search('cannot remove existing formatting and/or devices on disk.*in safe mode') and
+                      not blivet_output.changed }}"
+            msg: "Unexpected behavior w/ existing data on specified disks"
+
+        - name: Create a partition pool on the disk already containing a file system w/o safe_mode
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: partition
+
+        - name: Verify the output
+          assert:
+            that: "{{ not blivet_output.failed }}"
+            msg: "failed to create partition pool over existing file system using default value of safe_mode"
+
+        - name: Clean up
+          include_role:
+            name: storage
+          vars:
+            storage_volumes:
+              - name: test1
+                type: disk
+                disks: "{{ unused_disks }}"
+                present: false
+
       ignore_errors: yes

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -175,6 +175,7 @@
       include_role:
         name: storage
       vars:
+        storage_safe_mode: false
         storage_volumes:
           - name: test1
             type: disk

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -80,14 +80,41 @@
                 fs_type: 'ext3'
                 disks: "{{ unused_disks }}"
 
-        - name: Verify the output
-          assert:
-            that: "{{ blivet_output.failed and
-                      blivet_output.msg|regex_search('cannot remove existing formatting on volume.*in safe mode') and
-                      not blivet_output.changed }}"
-            msg: "Unexpected behavior w/ existing data on specified disks"
+        - name: UNREACH
+          fail:
+            msg: "this should be unreachable"
 
-        - name: Try to create a partition pool on the disk already containing a file system in safe_mode
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_task.name != 'UNREACH'
+            msg: "Role has not failed when it should have"
+          vars:
+            # Ugh! needed to expand ansible_failed_task
+            storage_provider: blivet
+
+    - name: Verify the output
+      assert:
+        that: "blivet_output.failed and
+               blivet_output.msg|regex_search('cannot remove existing formatting on volume.*in safe mode') and
+                  not blivet_output.changed"
+        msg: "Unexpected behavior w/ existing data on specified disks"
+
+    - name: stat the file
+      stat:
+        path: "{{ testfile }}"
+      register: stat_r
+
+    - name: assert file presence
+      assert:
+        that:
+          stat_r.stat.isreg is defined and stat_r.stat.isreg
+        msg: "data lost!"
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Try to create a LVM pool on the disk already containing a file system in safe_mode
           include_role:
             name: storage
           vars:

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -22,7 +22,7 @@
             storage_volumes:
               - name: test1
                 type: disk
-                disks: "['/dev/surelyidonotexist']"
+                disks: ['/dev/surelyidonotexist']
                 mount_point: "{{ mount_location }}"
 
         - name: Check the error output

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -3,6 +3,7 @@
   become: true
   vars:
     mount_location: '/opt/test1'
+    testfile: "{{ mount_location }}/quux"
 
   tasks:
     - include_role:
@@ -50,19 +51,24 @@
         #     that: blivet_output.failed | bool
         #     msg: "Expected error message not found for missing disk"
 
+    - name: Create a file system on disk
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            fs_type: 'ext4'
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+
+    - name: create a file
+      file:
+        path: "{{ testfile }}"
+        state: touch
 
     - name: Test for correct handling of safe_mode
       block:
-        - name: Create a file system on disk
-          include_role:
-            name: storage
-          vars:
-            storage_volumes:
-              - name: test1
-                type: disk
-                fs_type: 'ext4'
-                disks: "{{ unused_disks }}"
-
         - name: Try to replace the file system on disk in safe mode
           include_role:
             name: storage

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -25,11 +25,31 @@
                 disks: ['/dev/surelyidonotexist']
                 mount_point: "{{ mount_location }}"
 
-        - name: Check the error output
+        - name: UNREACH
+          fail:
+            msg: "this should be unreachable"
+
+      rescue:
+        - name: Check that we failed in the role
           assert:
-            that: "{{ blivet_output.failed }}"
-            msg: "Expected error message not found for missing disk"
-      ignore_errors: yes
+            that:
+              - ansible_failed_task.name != 'UNREACH'
+            msg: "Role has not failed when it should have"
+          vars:
+            # Ugh! needed to expand ansible_failed_task
+            storage_provider: blivet
+
+        # the following does not work properly,
+        # blivet_output.failed is false.
+        # - name: Show the error output
+        #   debug:
+        #     msg: "{{ blivet_output.failed }}"
+
+        # - name: Check the error output
+        #   assert:
+        #     that: blivet_output.failed | bool
+        #     msg: "Expected error message not found for missing disk"
+
 
     - name: Test for correct handling of safe_mode
       block:

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -124,36 +124,59 @@
                 disks: "{{ unused_disks }}"
                 type: partition
 
+        - name: UNREACH
+          fail:
+            msg: "this should be unreachable"
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_task.name != 'UNREACH'
+            msg: "Role has not failed when it should have"
+          vars:
+            # Ugh! needed to expand ansible_failed_task
+            storage_provider: blivet
+
         - name: Verify the output
           assert:
-            that: "{{ blivet_output.failed and
-                      blivet_output.msg|regex_search('cannot remove existing formatting and/or devices on disk.*in safe mode') and
-                      not blivet_output.changed }}"
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('cannot remove existing formatting and/or devices on disk.*in safe mode') and
+                   not blivet_output.changed"
             msg: "Unexpected behavior w/ existing data on specified disks"
 
-        - name: Create a partition pool on the disk already containing a file system w/o safe_mode
-          include_role:
-            name: storage
-          vars:
-            storage_safe_mode: false
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks }}"
-                type: partition
+    - name: stat the file
+      stat:
+        path: "{{ testfile }}"
+      register: stat_r
 
-        - name: Verify the output
-          assert:
-            that: "{{ not blivet_output.failed }}"
-            msg: "failed to create partition pool over existing file system using default value of safe_mode"
+    - name: assert file presence
+      assert:
+        that:
+          stat_r.stat.isreg is defined and stat_r.stat.isreg
+        msg: "data lost!"
 
-        - name: Clean up
-          include_role:
-            name: storage
-          vars:
-            storage_volumes:
-              - name: test1
-                type: disk
-                disks: "{{ unused_disks }}"
-                present: false
+    - name: Create a LVM pool on the disk already containing a file system w/o safe_mode
+      include_role:
+        name: storage
+      vars:
+        storage_safe_mode: false
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: partition
 
-      ignore_errors: yes
+    - name: Verify the output
+      assert:
+        that: not blivet_output.failed
+        msg: "failed to create LVM pool over existing file system using default value of safe_mode"
+
+    - name: Clean up
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            disks: "{{ unused_disks }}"
+            present: false

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -82,6 +82,7 @@
           include_role:
             name: storage
           vars:
+            storage_safe_mode: false
             storage_pools:
               - name: foo
                 disks: "{{ unused_disks }}"

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -202,9 +202,7 @@
 
         - name: Verify the output
           assert:
-            that: "{{ blivet_output.failed and
-                      blivet_output.msg|regex_search('cannot resize existing volume.*in safe mode') and
-                      not blivet_output.changed }}"
+            that: "{{ not blivet_output.failed and blivet_output.changed }}"
             msg: "Unexpected behavior w/ existing data on specified disks"
 
         - name: Try to create LVM pool on disks that already belong to an existing pool

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -149,3 +149,89 @@
                       not blivet_output.changed }}"
             msg: "Unexpected behavior w/ LVM volume defined outside of any pool"
       ignore_errors: yes
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Create a pool
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: testpool1
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: testvol1
+                    fs_type: 'ext4'
+                    size: '1g'
+
+        - name: Try to replace file system in safe mode
+          include_role:
+            name: storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: testpool1
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: testvol1
+                    fs_type: 'ext3'
+                    size: '1g'
+
+        - name: Verify the output
+          assert:
+            that: "{{ blivet_output.failed and
+                      blivet_output.msg|regex_search('cannot remove existing formatting on volume.*in safe mode') and
+                      not blivet_output.changed }}"
+            msg: "Unexpected behavior w/ existing data on specified disks"
+
+        - name: Try to resize in safe mode
+          include_role:
+            name: storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: testpool1
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: testvol1
+                    fs_type: 'ext4'
+                    size: '2g'
+
+        - name: Verify the output
+          assert:
+            that: "{{ blivet_output.failed and
+                      blivet_output.msg|regex_search('cannot resize existing volume.*in safe mode') and
+                      not blivet_output.changed }}"
+            msg: "Unexpected behavior w/ existing data on specified disks"
+
+        - name: Try to create LVM pool on disks that already belong to an existing pool
+          include_role:
+            name: storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: lvm
+
+        - name: Verify the output
+          assert:
+            that: "{{ blivet_output.failed and
+                      blivet_output.msg|regex_search('cannot remove existing formatting and/or devices on disk.*in safe mode') and
+                      not blivet_output.changed }}"
+            msg: "Unexpected behavior w/ existing data on specified disks"
+
+        - name: Clean up
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: testpool1
+                type: lvm
+                disks: "{{ unused_disks }}"
+                state: absent
+
+      ignore_errors: yes


### PR DESCRIPTION
Otherwise super() fails. Not necessary with Python 3, but necessary with Python 2 (where classic classes are the default)