### PR TITLE
Replace selectattr filter with json_query filter

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -51,6 +51,8 @@
 
 - name: Apply defaults to pools and volumes [4/6]
   set_fact:
+    # json_query(...) used instead of "|selectattr('pool', 'equalto', item.name)|list"
+    # as that expression wouldn't work with Jinja versions <2.8
     _storage_vols_no_defaults_by_pool: "{{ _storage_vols_no_defaults_by_pool|default({})|
                                         combine({item.name: _storage_vols_w_defaults|json_query('[?pool==`\"{}\"`]'.format(item.name))}) }}"
   loop: "{{ _storage_pools }}"

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -52,7 +52,7 @@
 - name: Apply defaults to pools and volumes [4/6]
   set_fact:
     _storage_vols_no_defaults_by_pool: "{{ _storage_vols_no_defaults_by_pool|default({})|
-                                        combine({item.name: _storage_vols_w_defaults|selectattr('pool', 'equalto', item.name)|list}) }}"
+                                        combine({item.name: _storage_vols_w_defaults|json_query('[?pool==`\"{}\"`]'.format(item.name))}) }}"
   loop: "{{ _storage_pools }}"
   when: storage_pools is defined
 

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -1,6 +1,8 @@
 ---
 - name: Set some facts
   set_fact:
+    # json_query(...) used instead of "|selectattr('device', 'equalto', storage_test_volume._device)|list"
+    # as that expression wouldn't work with Jinja versions <2.8
     storage_test_mount_device_matches: "{{ ansible_mounts|json_query('[?device==`\"{}\"`]'.format(storage_test_volume._device))}}"
     storage_test_mount_point_matches: "{{ ansible_mounts|json_query('[?mount==`\"{}\"`]'.format(storage_test_volume.mount_point))}}"
     storage_test_mount_expected_match_count: "{{ 1 if _storage_test_volume_present and storage_test_volume.mount_point else 0 }}"

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -1,8 +1,8 @@
 ---
 - name: Set some facts
   set_fact:
-    storage_test_mount_device_matches: "{{ ansible_mounts|selectattr('device', 'equalto', storage_test_volume._device)|list }}"
-    storage_test_mount_point_matches: "{{ ansible_mounts|selectattr('mount', 'equalto', storage_test_volume.mount_point)|list }}"
+    storage_test_mount_device_matches: "{{ ansible_mounts|json_query('[?device==`\"{}\"`]'.format(storage_test_volume._device))}}"
+    storage_test_mount_point_matches: "{{ ansible_mounts|json_query('[?mount==`\"{}\"`]'.format(storage_test_volume.mount_point))}}"
     storage_test_mount_expected_match_count: "{{ 1 if _storage_test_volume_present and storage_test_volume.mount_point else 0 }}"
 
 #


### PR DESCRIPTION
Some tests (like comparison) are missing in older Jinja. That makes
selectattr filter unusable on RHEL 7.