### PR TITLE
Specify Python 2 for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,5 @@
+---
+extraction:
+  python:
+    python_setup:
+      version: 2

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -122,7 +122,7 @@ class BlivetAnsibleError(Exception):
     pass
 
 
-class BlivetVolume:
+class BlivetVolume(object):
     def __init__(self, blivet_obj, volume, bpool=None):
         self._blivet = blivet_obj
         self._volume = volume
@@ -346,7 +346,7 @@ def _get_blivet_volume(blivet_obj, volume, bpool=None):
     return _BLIVET_VOLUME_TYPES[volume_type](blivet_obj, volume, bpool=bpool)
 
 
-class BlivetPool:
+class BlivetPool(object):
     def __init__(self, blivet_obj, pool):
         self._blivet = blivet_obj
         self._pool = pool


### PR DESCRIPTION
LGTM defaults to Python 3 for the storage role because it was created
recently. Since it needs to support Python 2 as well, configure it
explicitly.

LGTM is a static code analyzer to identify bugs in code, it found real issues that I fixed in PR #52.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linux-system-roles/storage/62)
<!-- Reviewable:end -->
