### PR TITLE
Fixes for bugs found during testing of 'missing parameters' changeset

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ storage_safe_mode: true  # fail instead of implicitly/automatically removing dev
 storage_pool_defaults:
   state: "present"
   type: lvm
+  volumes: []
 
 storage_volume_defaults:
   state: "present"

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -167,7 +167,7 @@ class BlivetVolume(object):
         fmt = get_format(self._volume['fs_type'],
                          mountpoint=self._volume.get('mount_point'),
                          label=self._volume['fs_label'],
-                         options=self._volume['fs_create_options'])
+                         create_options=self._volume['fs_create_options'])
         if not fmt.supported or not fmt.formattable:
             raise BlivetAnsibleError("required tools for file system '%s' are missing" % self._volume['fs_type'])
 

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -251,6 +251,9 @@ class BlivetVolume(object):
         if self._device.exists:
             self._reformat()
 
+        if self.ultimately_present and self._volume['mount_point'] and not self._device.format.mountable:
+            raise BlivetAnsibleError("volume '%s' has a mount point but no mountable file system" % self._volume['name'])
+
         # schedule resize if appropriate
         if self._device.exists and self._volume['size']:
             self._resize()

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -209,6 +209,8 @@ class BlivetVolume(object):
                 raise BlivetAnsibleError("volume '%s' cannot be resized from %s to %s: %s" % (self._device.name,
                                                                                               self._device.size,
                                                                                               size, str(e)))
+        elif size and self._device.size != size and not self._device.resizable:
+            raise BlivetAnsibleError("volume '%s' cannot be resized from %s to %s" % (self._device.name, self._device.size, size))
 
     def _reformat(self):
         """ Schedule actions as needed to ensure the volume is formatted as specified. """

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -226,6 +226,8 @@ class BlivetVolume(object):
 
         if self._device.format.status and not packages_only:
             self._device.format.teardown()
+        if not self._device.isleaf:
+            self._blivet.devicetree.recursive_remove(self._device, remove_device=False)
         self._blivet.format_device(self._device, fmt)
 
     def manage(self):


### PR DESCRIPTION
__NOTE__: This will need to be rebased once the `safe_mode` changes are merged.

`Fix key for partition pool...`
This leads to a failure (crash?) any time a pool of type 'partition' is present.

`Don't unmount anything if only...`
This one is pretty self-explanatory.

`Add proper checking of specified disk...`
We already validate the supplied value of `disks` for all pools, but not for disk volumes.

`Fix passing of fs create options...`
We were incorrectly passing user-specified mkfs arguments to blivet, causing them to be ignored.

`Fail on request to resize unresizable...`
We should not silently fail if the user requests a resize of a non-resizable volume.

`Remove partitions etc as needed...`
This is _sort of_ a special-case for disk volumes, but it could be needed for other types as well.

`Fail w/ error if mount specified...`
Error out early if the user specifies mounting of a non-mountable formatting type.

`Add a default empty volume list to...`
This solves current crashes when a pool is defined with no `volumes` list.
