### PR TITLE
Manually manage swap entries in /etc/fstab.

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -138,10 +138,28 @@
   loop_control:
     loop_var: mount_info
 
+- name: manage swap entries in /etc/fstab manually
+  lineinfile:
+    path: /etc/fstab
+    regex: "{{ swap_info['regex'] }}"
+    state: "{{ swap_info['state'] }}"
+    line: "{{ swap_info.get('line', 'omit') }}"
+  loop: "{{ blivet_output.swaps }}"
+  loop_control:
+      loop_var: swap_info
+
+
+- name: manage state of swaps
+  command: swapon "{{ swap_info['device'] }}"
+  when: swap_info['state'] == 'present'
+  loop: "{{ blivet_output.swaps }}"
+  loop_control:
+      loop_var: swap_info
+
 - name: tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: yes
-  when: blivet_output['mounts']
+  when: blivet_output['mounts'] or blivet_output['swaps']
 
 #
 # Update facts since we may have changed system state.

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -146,7 +146,7 @@
     line: "{{ swap_info.get('line', 'omit') }}"
   loop: "{{ blivet_output.swaps }}"
   loop_control:
-      loop_var: swap_info
+    loop_var: swap_info
 
 
 - name: manage state of swaps
@@ -154,7 +154,7 @@
   when: swap_info['state'] == 'present'
   loop: "{{ blivet_output.swaps }}"
   loop_control:
-      loop_var: swap_info
+    loop_var: swap_info
 
 - name: tell systemd to refresh its view of /etc/fstab
   systemd:

--- a/tests/test-verify-volume-fstab.yml
+++ b/tests/test-verify-volume-fstab.yml
@@ -3,7 +3,8 @@
   set_fact:
     storage_test_fstab_id_matches: "{{ storage_test_fstab.stdout_lines|map('regex_search', '^' + storage_test_volume._mount_id + ' ')|select('string')|list }}"
     storage_test_fstab_mount_point_matches: "{{ storage_test_fstab.stdout_lines|map('regex_search', ' +' + storage_test_volume.mount_point + ' +')|select('string')|list if storage_test_volume.mount_point else [] }}"
-    storage_test_fstab_expected_matches: "{{ 1 if (_storage_test_volume_present and storage_test_volume.mount_point) else 0 }}"
+    storage_test_fstab_expected_matches: "{{ 1 if (_storage_test_volume_present and (storage_test_volume.mount_point or storage_test_volume.fs_type == 'swap')) else 0 }}"
+    storage_test_fstab_expected_mount_point_matches: "{{ 1 if (_storage_test_volume_present and storage_test_volume.mount_point) else 0 }}"
 
 # device id
 - name: Verify that the device identifier appears in /etc/fstab
@@ -15,7 +16,7 @@
 # mount point
 - name: Verify the fstab mount point
   assert:
-    that: "{{ storage_test_fstab_mount_point_matches|length == storage_test_fstab_expected_matches|int }}"
+    that: "{{ storage_test_fstab_mount_point_matches|length == storage_test_fstab_expected_mount_point_matches|int }}"
     msg: "Expected number ({{ storage_test_fstab_expected_matches }}) of entries with volume '{{ storage_test_volume.name }}' mount point not found in /etc/fstab."
 
 # todo: options

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -3,7 +3,7 @@
   set_fact:
     storage_test_mount_device_matches: "{{ ansible_mounts|selectattr('device', 'equalto', storage_test_volume._device)|list }}"
     storage_test_mount_point_matches: "{{ ansible_mounts|selectattr('mount', 'equalto', storage_test_volume.mount_point)|list }}"
-    storage_test_mount_expected_match_count: "{{ 1 if _storage_test_volume_present and storage_test_volume.mount_point else 0 }}"
+    storage_test_mount_expected_match_count: "{{ 1 if _storage_test_volume_present and storage_test_volume.mount_point and storage_test_volume.fs_type != 'swap' else 0 }}"
 
 #
 # Verify mount presence.


### PR DESCRIPTION
The 'mount' module removes pre-existing entries that match the
mount point of a new entry, which is problematic for swap since
they all have the same mount point: 'swap'.