### PR TITLE
use tox; use latest template code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 passes.yml
 vault.yml
+*.pyc
 *.retry
-
+/tests/.coverage
+/tests/htmlcov*
+/.tox
+/venv*/
+/.venv/
+.vscode/
+artifacts/
+__pycache__/
+*~
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
+# SPDX-License-Identifier: MIT
 ---
+dist: xenial
 language: python
+env:
+  global:
+    - LSR_ANSIBLES='ansible==2.7.* ansible==2.8.* ansible==2.9.*'
+    - LSR_MSCENARIOS='default'
+matrix:
+  include:
+    - python: 2.6
+      dist: trusty
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
+    - python: 3.8-dev
+
 services:
   - docker
+
+before_install:
+  - ./.travis/preinstall
+
 install:
-  - pip install 'molecule<3' docker
+  - pip install tox tox-travis
+
 script:
-  - molecule --version
-  - ansible --version
-  - molecule lint
-  - molecule syntax
-  - molecule test
+  - ./.travis/runtox

--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+#
+# Use this file to specify custom configuration for a project. Generally, this
+# involves the modification of the content of LSR_* environment variables, see
+#
+#   * .travis/preinstall:
+#
+#       - LSR_EXTRA_PACKAGES
+#
+#   * .travis/runtox:
+#
+#       - LSR_ANSIBLES
+#       - LSR_MSCENARIOS
+#
+#   * .travis/runcoveralls.sh:
+#
+#       - LSR_PUBLISH_COVERAGE
+#       - LSR_TESTSDIR
+#       - function lsr_runcoveralls_hook
+#
+# Environment variables that not start with LSR_* but have influence on CI
+# process:
+#
+#   * .travis/runpylint.sh:
+#
+#       - RUN_PYLINT_INCLUDE
+#       - RUN_PYLINT_EXCLUDE
+#       - RUN_PYLINT_DISABLED
+#
+#   * .travis/runblack.sh:
+#
+#       - RUN_BLACK_INCLUDE
+#       - RUN_BLACK_EXCLUDE
+#       - RUN_BLACK_DISABLED
+#       - RUN_BLACK_EXTRA_ARGS
+#
+#   * .travis/runflake8.sh:
+#
+#       - RUN_FLAKE8_DISABLED
+#       - RUN_FLAKE8_IGNORE
+#
+#   * .travis/runsyspycmd.sh:
+#
+#       - function lsr_runsyspycmd_hook
+RUN_BLACK_DISABLED=true
+RUN_FLAKE8_DISABLED=true
+# if your script needs to setup module_utils so that your
+# module_utils/ code can be resolved by the default
+# pythonpath resolver, an IDE, etc. then call
+lsr_setup_module_utils
+# here

--- a/.travis/custom.sh
+++ b/.travis/custom.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+# Write your custom commands here that should be run when `tox -e custom`:

--- a/.travis/custom_pylint.py
+++ b/.travis/custom_pylint.py
@@ -1,0 +1,171 @@
+#                                                         -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""
+Probe directory tree for python files and pass them to pylint.
+
+Usage: python custom_pylint.py ARGUMENTS
+
+Run pylint with ARGUMENTS followed by the list of python files contained in the
+working directory and its subdirectories.  As a python file is recognized a
+file that match INCPAT.  Files and directories that match EXPAT are skipped.
+Symbolic links are also skipped.  It is assumed that files to be pylinted are
+specified only with INCPAT and EXPAT.
+
+There are several cases when argument from ARGUMENTS is not passed to pylint
+but it is handled by run_pylint.py instead:
+
+  1. if -h or --help is contained in ARGUMENTS, this help screen is printed to
+     the standard output and run_pylint.py exits with 0;
+  2. if --include followed by a PATTERN is contained in ARGUMENTS, the PATTERN
+     is used instead of INCPAT to recognize whether the file is a python file
+     or not;
+  3. if --exclude followed by a PATTERN is contained in ARGUMENTS, the PATTERN
+     is used instead of EXPAT to recognize whether the file or directory should
+     be skipped.
+
+Exclusion takes a priority over inclusion, i.e. if a file or directory can be
+both included and excluded, it is excluded.
+
+The default value of INCPAT is .*\\.py[iw]?$.  For EXPAT, it is ^\\..*.
+
+Environment variables:
+
+  RUN_PYLINT_INCLUDE
+    overrides default value of INCPAT;
+
+  RUN_PYLINT_EXCLUDE
+    overrides default value of EXPAT;
+
+  RUN_PYLINT_DISABLED
+    if set to an arbitrary non-empty value, pylint will be not executed
+"""
+
+import os
+import re
+import sys
+
+from colorama import Fore
+from pylint.lint import Run
+
+
+def blue(s):
+    """
+    Return string `s` colorized to blue.
+    """
+
+    return "%s%s%s" % (Fore.BLUE, s, Fore.RESET)
+
+
+def print_line(s):
+    """
+    Write `s` followed by the line feed character to the standard output.
+    """
+
+    sys.stdout.write("%s\n" % s)
+
+
+def probe_args():
+    """
+    Analyze the command line arguments and return a tuple containing a list of
+    pylint arguments, pattern string to recognize files to be included, and
+    pattern string to recognize files and directories to be skipped.
+
+    Default values of pattern strings are taken from RUN_PYLINT_INCLUDE and
+    RUN_PYLINT_EXCLUDE environment variables. In the case they are not defined,
+    .*\\.py[iw]?$ and ^\\..* are used, respectively.
+    """
+
+    args = []
+    include_pattern = os.getenv("RUN_PYLINT_INCLUDE", r".*\.py[iw]?$")
+    exclude_pattern = os.getenv("RUN_PYLINT_EXCLUDE", r"^\..*")
+    i, nargs = 1, len(sys.argv)
+    while i < nargs:
+        arg = sys.argv[i]
+        if arg == "--include":
+            i += 1
+            assert i < nargs, "--include: missing PATTERN"
+            include_pattern = sys.argv[i]
+        elif arg == "--exclude":
+            i += 1
+            assert i < nargs, "--exclude: missing PATTERN"
+            exclude_pattern = sys.argv[i]
+        else:
+            args.append(arg)
+        i += 1
+    return args, include_pattern, exclude_pattern
+
+
+def probe_dir(path, include_re, exclude_re):
+    """
+    Recursively go through directory structure starting at `path`, collect
+    files that match `include_re`, skip files and directories that are either
+    symbolic links or match `exclude_re`. Return the list of collected files.
+    """
+
+    files = []
+    for direntry in os.listdir(path):
+        fullpath = os.path.join(path, direntry)
+        if os.path.islink(fullpath) or exclude_re.match(direntry):
+            continue
+        elif os.path.isdir(fullpath):
+            files.extend(probe_dir(fullpath, include_re, exclude_re))
+        elif os.path.isfile(fullpath) and include_re.match(direntry):
+            files.append(fullpath)
+    return files
+
+
+def show_files(files):
+    """
+    Print `files` to the standard output, one item per line, in a blue color.
+    """
+
+    print_line(blue("%s: files to be checked:" % sys.argv[0]))
+    for f in files:
+        print_line(blue("    %s" % f))
+
+
+def main():
+    """
+    Script entry point. Return exit code.
+    """
+
+    args, include_pattern, exclude_pattern = probe_args()
+    if "-h" in args or "--help" in args:
+        print_line(__doc__)
+        return 0
+    if os.getenv("RUN_PYLINT_DISABLED", "") != "":
+        return 0
+    files = probe_dir(
+        os.getcwd(), re.compile(include_pattern), re.compile(exclude_pattern)
+    )
+    if not files:
+        return 0
+    show_files(files)
+    args.extend(files)
+    sys.argv[0] = "pylint"
+    return Run(args, None, False).linter.msg_status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.travis/preinstall
+++ b/.travis/preinstall
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Install package specified by user in LSR_EXTRA_PACKAGES. Executed by Travis
+# during before_install phase.
+#
+# LSR_EXTRA_PACKAGES, set by user in .travis/config.sh, is a space separated
+# list of packages to be installed on the Travis build environment (Ubuntu).
+
+set -e
+
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+
+# Add python3-selinux package (needed by Molecule on selinux enabled systems,
+# because Molecule is using `copy` and `file` Ansible modules to setup the
+# container).
+if lsr_venv_python_matches_system_python; then
+  LSR_EXTRA_PACKAGES='python3-selinux'
+fi
+
+# extra packages needed with python 2.6 and ansible 2.6
+if lsr_check_python_version python -lt 2.7 ; then
+  LSR_EXTRA_PACKAGES="$LSR_EXTRA_PACKAGES libffi-dev libssl-dev"
+fi
+
+. ${SCRIPTDIR}/config.sh
+
+# Install extra dependencies.
+if [[ "${LSR_EXTRA_PACKAGES}" ]]; then
+  set -x
+  sudo apt-get update
+  sudo apt-get install -y ${LSR_EXTRA_PACKAGES}
+fi

--- a/.travis/runblack.sh
+++ b/.travis/runblack.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around black (Python formatter). The purpose of this wrapper
+# is to get a user the opportunity to control black from config.sh via setting
+# environment variables.
+
+# The given command line arguments are passed to black.
+
+# Environment variables:
+#
+#   RUN_BLACK_INCLUDE
+#     a regular expression specifying files to be included; can be overridden
+#     from command line by --include;
+#
+#   RUN_BLACK_EXCLUDE
+#     a regular expression specifying files to be excluded; can be overridden
+#     from command line by --exclude;
+#
+#   RUN_BLACK_DISABLED
+#     if set to an arbitrary non-empty value, black will be not executed
+#
+#   RUN_BLACK_EXTRA_ARGS
+#     extra cmd line args to pass to black
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+if [[ "${RUN_BLACK_DISABLED}" ]]; then
+  lsr_info "${ME}: black is disabled. Skipping."
+  exit 0
+fi
+
+DEFAULT_INCLUDE='^[^.].*\.py$'
+DEFAULT_EXCLUDE='/(\.[^.].*|tests/roles)/'
+
+INCLUDE_ARG=""
+EXCLUDE_ARG=""
+OTHER_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --include)
+      shift
+      INCLUDE_ARG="$1"
+      ;;
+    --exclude)
+      shift
+      EXCLUDE_ARG="$1"
+      ;;
+    *)
+      OTHER_ARGS+=( "$1" )
+      ;;
+  esac
+  shift
+done
+
+set -x
+python -m black \
+  --include "${INCLUDE_ARG:-${RUN_BLACK_INCLUDE:-${DEFAULT_INCLUDE}}}" \
+  --exclude "${EXCLUDE_ARG:-${RUN_BLACK_EXCLUDE:-${DEFAULT_EXCLUDE}}}" \
+  ${RUN_BLACK_EXTRA_ARGS:-} \
+  "${OTHER_ARGS[@]}"

--- a/.travis/runcoveralls.sh
+++ b/.travis/runcoveralls.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Reports coverage results using coveralls. The aim of this script is to
+# provide a unified way to reporting coverage results across all linux system
+# roles projects.
+
+# The given command line arguments are passed to coveralls.
+
+# Environment variables:
+#
+#   LSR_PUBLISH_COVERAGE
+#     if the variable is empty or unset, nothing will be published; if the
+#     variable has its value set to 'strict', the reporting is performed in
+#     strict mode, so situations like missing data to be reported are treated
+#     as errors; if the value of this variable is 'debug', coveralls is run in
+#     debug mode (see coveralls debug --help); other values cause that coverage
+#     results will be reported normally
+#   LSR_TESTSDIR
+#     a path to directory where tests and tests artifacts are located; if unset
+#     or empty, this variable is set to ${TOPDIR}/tests; this path should
+#     already exists and be populated with tests artifacts before the script
+#     starts performing actions on it
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+# Publish the results only if it is desired.
+if [[ -z "${LSR_PUBLISH_COVERAGE}" ]]; then
+  lsr_info "${ME}: Publishing coverage report is not enabled. Skipping."
+  exit 0
+fi
+
+LSR_TESTSDIR=${LSR_TESTSDIR:-${TOPDIR}/tests}
+
+# Ensure we are in $LSR_TESTSDIR. It is supposed that if a user wants to submit
+# tests results, $LSR_TESTSDIR always exists.
+cd ${LSR_TESTSDIR}
+
+# For simplicity, we suppose that coverage core data file has name .coverage
+# and it is situated in $LSR_TESTSDIR. Similarly for .coveragerc.
+COVERAGEFILE='.coverage'
+COVERAGERCFILE='.coveragerc'
+
+# In case there is no $COVERAGEFILE, there is nothing to report. If we are
+# running in strict mode, treat this situation as error.
+if [[ ! -s ${COVERAGEFILE} ]]; then
+  NO_COVERAGEFILE_MSG="${COVERAGEFILE} is missing or empty"
+  if [[ "${LSR_PUBLISH_COVERAGE}" == "strict" ]]; then
+    lsr_error "${ME} (strict mode): ${NO_COVERAGEFILE_MSG}!"
+  fi
+  lsr_info "${ME}: ${NO_COVERAGEFILE_MSG}, nothing to publish."
+  exit 0
+fi
+
+# Create $COVERAGERCFILE file with a [paths] section. From the official docs:
+#
+#   The first value must be an actual file path on the machine where the
+#   reporting will happen, so that source code can be found. The other values
+#   can be file patterns to match against the paths of collected data, or they
+#   can be absolute or relative file paths on the current machine.
+#
+# So in our $COVERAGERCFILE file we make both locations to point to the
+# project's top directory.
+cat > ${COVERAGERCFILE} <<EOF
+[paths]
+source =
+    ..
+    $(readlink -f ..)
+EOF
+
+# Rename $COVERAGEFILE to ${COVERAGEFILE}.merge. With this trick, coverage
+# combine applies configuration in $COVERAGERCFILE also to $COVERAGEFILE.
+mv ${COVERAGEFILE} ${COVERAGEFILE}.merge
+python -m coverage combine --append
+
+MAYBE_DEBUG=""
+if [[ "${LSR_PUBLISH_COVERAGE}" == "debug" ]]; then
+  MAYBE_DEBUG=debug
+fi
+
+set -x
+coveralls ${MAYBE_DEBUG} "$@"

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around flake8. The purpose of this wrapper is to get to user
+# an opportunity to disable running flake8 via config.sh.
+
+# The given command line arguments are passed to flake8.
+
+# Environment variables:
+#
+#   RUN_FLAKE8_DISABLED
+#     if set to an arbitrary non-empty value, flake8 will be not executed
+#   RUN_FLAKE8_IGNORE
+#     list of issues to ignore - see flake8 docs
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+if [[ "${RUN_FLAKE8_DISABLED}" ]]; then
+  lsr_info "${ME}: flake8 is disabled. Skipping."
+  exit 0
+fi
+
+set -x
+python -m flake8 \
+  ${RUN_FLAKE8_IGNORE:+--ignore} ${RUN_FLAKE8_IGNORE:-} \
+  "$@"

--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around custom_pylint.py. The purpose of this wrapper is to
+# set environment variables defined in config.sh before custom_pylint.py
+# invocation, so user can control what should be pylinted via config.sh.
+
+# Note: Prior this change, RUN_PYLINT_* environment variables set in config.sh
+#       take effect only when running inside Travis (because of runtox script
+#       which set them by including config.sh). Now, they take effect also when
+#       running tox locally.
+
+# The given command line arguments are passed to custom_pylint.py.
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+set -x
+python ${SCRIPTDIR}/custom_pylint.py "$@"

--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# A shell wrapper around pytest. As pytest is sensitive on a content of project
+# directory: if a project contains no unit tests, pytest fails. Similarly if
+# there is nothing to be analyzed with coverage, running pytest with --cov*
+# arguments may lead to problems. For this reasons, this shell wrapper skips
+# running pytest if there are no unit tests and filters out --cov*/--no-cov*
+# arguments if there is nothing to be analyzed with coverage.
+
+# The given command line arguments are passed to pytest.
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+if [[ ! -d ${TOPDIR}/tests/unit ]]; then
+  lsr_info "${ME}: No unit tests found. Skipping."
+  exit 0
+fi
+
+PYTEST_OPTS=()
+PYTEST_OPTS_NOCOV=()
+USE_COV=no
+
+# Filter out coverage options if there is nothing to be analyzed with coverage.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cov=*)
+      if [[ "${1:6}" && -d "${1:6}" ]]; then
+        USE_COV=yes
+        PYTEST_OPTS+=( "$1" )
+      fi
+      ;;
+    --cov*|--no-cov*)
+      PYTEST_OPTS+=( "$1" )
+      ;;
+    *)
+      PYTEST_OPTS+=( "$1" )
+      PYTEST_OPTS_NOCOV+=( "$1" )
+      ;;
+  esac
+  shift
+done
+
+if [[ "${USE_COV}" == "no" ]]; then
+  PYTEST_OPTS=( "${PYTEST_OPTS_NOCOV[@]}" )
+fi
+
+set -x
+python -m pytest "${PYTEST_OPTS[@]}"

--- a/.travis/runsyspycmd.sh
+++ b/.travis/runsyspycmd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Execute command in environment python only if environment python has access
+# to system python libraries, especially C bindings. The script is run with
+# these arguments:
+#
+#   $1     - command runnable in Python (should be present in $PATH)
+#   ${@:2} - arguments passed to $1
+
+set -e
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+if ! lsr_venv_python_matches_system_python ; then
+  lsr_info "${ME}: ${1:-<missing command>}:" \
+    "Environment Python has no access to system Python libraries. Skipping."
+  exit 0
+fi
+
+COMMAND=$(command -v $1)
+shift
+
+set -x
+python ${COMMAND} "$@"

--- a/.travis/runtox
+++ b/.travis/runtox
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# Run tox. Additionally, if LSR_MSCENARIOS is defined, run `tox -e molecule`
+# for every scenario from LSR_MSCENARIOS and for every Ansible version from
+# LSR_ANSIBLES.
+#
+# LSR_MSCENARIOS is a space separated list of molecule scenarios.
+# LSR_ANSIBLES is a space separated list of Ansible package names with versions
+# in pip format, i.e 'ansible ansible==2.6 ansible==2.7 ansible=2.8'.
+#
+# LSR_MSCENARIOS and LSR_ANSIBLES can be set in .travis/config.sh or as
+# environment variables.
+
+ME=$(basename $0)
+SCRIPTDIR=$(readlink -f $(dirname $0))
+BANNERSIZE=90
+
+. ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
+
+lsr_banner "tox" ${BANNERSIZE}
+(set -x; tox); error_code=$?
+
+# Exit prematurely if the environment is not suitable for running
+# Molecule tests.
+if ! lsr_venv_python_matches_system_python; then
+  exit $error_code
+fi
+
+for ansible_dependency in ${LSR_ANSIBLES}; do
+  for molecule_scenario in ${LSR_MSCENARIOS}; do
+    lsr_banner \
+      "[${ansible_dependency}] tox -e molecule -- -s ${molecule_scenario}" \
+      ${BANNERSIZE}
+    (
+      set -x
+      LSR_ANSIBLE_DEP="${ansible_dependency}" \
+      LSR_MSCENARIO=${molecule_scenario} \
+      tox -e molecule
+    ) || error_code=$?
+  done
+done
+
+exit $error_code

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: MIT
+#
+# Auxiliary functions and variables.
+#
+# Usage: . utils.sh
+
+# All variables prefixed with __lsr_ are internal.
+
+# Code that prints the version of Python interpreter to standard output; it
+# should be compatible across Python 2 and Python 3, the version is printed as
+# "{major}.{minor}".
+__lsr_get_python_version_py='
+import sys
+
+sys.stdout.write("%s.%s\n" % sys.version_info[:2])
+'
+
+# Colors for lsr_banner, lsr_info, and lsr_error.
+__lsr_color_reset='\e[0m'
+__lsr_color_red='\e[31m'
+__lsr_color_blue='\e[34m'
+__lsr_color_yellow='\e[1;33m'
+
+##
+# lsr_banner $1 [$2]
+#
+#   $1 - banner text
+#   $2 - number of columns to occupy (default: 79)
+#
+# Print banner (in yellow) with $1 to stdout.
+function lsr_banner() {
+  local maxlen=${2:-79}
+  local fillchar='_'
+  local text=" ${1} "
+  local fillsize=$(( ${maxlen} - ${#text} ))
+  local line1
+  local line2
+
+  if [[ ${fillsize} -lt 0 ]]; then
+    maxlen=${#text}
+    fillsize=0
+  fi
+
+  line1=$(printf "%*s" ${maxlen} "" | tr " " "${fillchar}")
+
+  if [[ $(( ${fillsize} % 2 )) -eq 1 ]]; then
+    text="${text} "
+  fi
+
+  line2=$(printf "%*s" $(( ${fillsize} / 2 )) "" | tr " " "${fillchar}")
+  line2="${line2}${text}${line2}"
+
+  echo -e "${__lsr_color_yellow}${line1}${__lsr_color_reset}"
+  echo -e "${__lsr_color_yellow}${line2}${__lsr_color_reset}"
+}
+
+##
+# lsr_info ARGS
+#
+# Print ARGS (in blue) to stdout.
+function lsr_info() {
+  echo -e "${__lsr_color_blue}$*${__lsr_color_reset}"
+}
+
+##
+# lsr_error ARGS
+#
+# Print ARGS (in red) to stderr and exit with exit code 1.
+function lsr_error() {
+  echo -e "${__lsr_color_red}$*${__lsr_color_reset}" >&2
+  exit 1
+}
+
+##
+# lsr_get_python_version $1
+#
+#   $1 - command or full path to Python interpreter
+#
+# If $1 is installed, return its version.
+function lsr_get_python_version() {
+  if command -v $1 >/dev/null 2>&1; then
+    $1 -c "${__lsr_get_python_version_py}"
+  fi
+}
+
+##
+# lsr_compare_versions $1 $2 $3
+#
+#   $1 - version string (see notes below)
+#   $2 - binary operation (see TEST(1))
+#   $3 - version string (see notes below)
+#
+# Exit with 0 if `$1 $2 $3`.
+#
+# Notes:
+#   A version string is of the format [:digit:] "." [:digit:].
+function lsr_compare_versions() {
+  if [[ $# -lt 3 ]]; then
+    return 1
+  fi
+
+  test ${1//./} $2 ${3//./}
+}
+
+##
+# lsr_check_python_version $1 $2 $3
+#
+#   $1 - command or full path to Python interpreter
+#   $2 - binary operation (see TEST(1))
+#   $3 - version string in [:digit:] "." [:digit:] format.
+#
+# Exit with 0 if `version($1) $2 $3`.
+function lsr_check_python_version() {
+  if [[ $# -lt 3 ]]; then
+    return 1
+  fi
+
+  lsr_compare_versions $(lsr_get_python_version $1) $2 $3
+}
+
+##
+# lsr_compare_pythons $1 $2 $3
+#
+#   $1 - command or full path to Python interpreter
+#   $2 - binary operation (see TEST(1))
+#   $3 - command or full path to Python interpreter
+#
+# Exit with 0 if `version($1) $2 version($3)`.
+function lsr_compare_pythons() {
+  if [[ $# -lt 3 ]]; then
+    return 1
+  fi
+
+  lsr_compare_versions \
+    $(lsr_get_python_version $1) $2 $(lsr_get_python_version $3)
+}
+
+##
+# lsr_get_system_python
+#
+# Return the system python, or /usr/bin/python3 if nothing
+# else can be found in a standard location.
+function lsr_get_system_python() {
+  local syspython=$(command -pv python3)
+  if [[ -z "$syspython" ]]; then
+    syspython=$(command -pv python)
+  fi
+  if [[ -z "$syspython" ]]; then
+    syspython=$(command -pv python2)
+  fi
+  echo ${syspython:-/usr/bin/python3}
+}
+
+##
+# lsr_venv_python_matches_system_python [$1] [$2]
+#
+#   $1 - command or full path to venv Python interpreter (default: python)
+#   $2 - command or full path to the system Python interpreter
+#        (default: /usr/bin/python3 or /usr/bin/python or /usr/bin/python2)
+#
+# Exit with 0 if virtual environment Python version matches the system Python
+# version.
+function lsr_venv_python_matches_system_python() {
+  local syspython="${2:-$(lsr_get_system_python)}"
+
+  lsr_compare_pythons ${1:-python} -eq $syspython
+}
+
+##
+# lsr_setup_module_utils [$1] [$2]
+#
+#   $1 - path to the ansible/module_utils/ directory in the venv
+#        assumes ansible has been installed in the venv
+#        defaults to env var $SRC_MODULE_UTILS_DIR
+#   $2 - path to the local module_utils/ directory for the role
+#        defaults to env var $DEST_MODULE_UTILS_DIR
+#
+# Exit with 0 if virtual environment Python version matches the system Python
+# version.
+function lsr_setup_module_utils() {
+  local srcdir=${1:-$SRC_MODULE_UTILS_DIR}
+  local destdir=${2:-$DEST_MODULE_UTILS_DIR}
+  if [ -n "$srcdir" -a -d "$srcdir" -a -n "$destdir" -a -d "$destdir" ]; then
+    bash $TOPDIR/tests/setup_module_utils.sh "$srcdir" "$destdir"
+  fi
+}
+
+# set TOPDIR
+ME=${ME:-$(basename $0)}
+SCRIPTDIR=${SCRIPTDIR:-$(readlink -f $(dirname $0))}
+TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
+
+# Local Variables:
+# mode: Shell-script
+# sh-basic-offset: 2
+# End:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+---
+extends: .yamllint_defaults.yml
+# possible customizations over the base yamllint config
+# skip the yaml files in the /tests/ directory
+# NOTE: If you want to customize `ignore` you'll have to
+# copy in all of the config from .yamllint.yml, then
+# add your own - so if you want to just add /tests/ to
+# be ignored, you'll have to add the ignores from the base
+ignore: |
+  /tests/
+  /.tox/
+# skip checking line length
+# NOTE: the above does not apply to `rules` - you do not
+# have to copy all of the rules from the base config
+rules:
+  line-length: disable

--- a/.yamllint_defaults.yml
+++ b/.yamllint_defaults.yml
@@ -1,4 +1,7 @@
+# SPDX-License-Identifier: MIT
 ---
+ignore: |
+  /.tox/
 extends: default
 rules:
   braces:
@@ -7,6 +10,5 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
   truthy: disable
   document-start: disable

--- a/ansible26_requirements.txt
+++ b/ansible26_requirements.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+
+# extra requirements for installing ansible 26
+idna<2.8
+PyYAML<5.1
+ansible<2.7

--- a/custom_requirements.txt
+++ b/custom_requirements.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+
+# Write requirements for running your custom commands in tox here:

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Molecule managed
 
 {% if item.registry is defined %}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 ---
 dependency:
   name: galaxy
@@ -6,10 +7,10 @@ driver:
 lint:
   name: yamllint
   options:
-    config-file: molecule/default/yamllint.yml
+    config-file: .yamllint.yml
 platforms:
   - name: centos-7
-    image: linuxsystemroles/centos-7
+    image: docker.io/linuxsystemroles/centos-7
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/molecule_extra_requirements.txt
+++ b/molecule_extra_requirements.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running molecule here:

--- a/pylint_extra_requirements.txt
+++ b/pylint_extra_requirements.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running pylint here:
+pytest

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: MIT
+
+# This file was generated using `pylint --generate-rcfile > pylintrc` command. 
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=.git,.tox
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=wrong-import-position
+#disable=print-statement,
+#        parameter-unpacking,
+#        unpacking-in-except,
+#        old-raise-syntax,
+#        backtick,
+#        long-suffix,
+#        old-ne-operator,
+#        old-octal-literal,
+#        import-star-module-level,
+#        non-ascii-bytes-literal,
+#        raw-checker-failed,
+#        bad-inline-option,
+#        locally-disabled,
+#        locally-enabled,
+#        file-ignored,
+#        suppressed-message,
+#        useless-suppression,
+#        deprecated-pragma,
+#        apply-builtin,
+#        basestring-builtin,
+#        buffer-builtin,
+#        cmp-builtin,
+#        coerce-builtin,
+#        execfile-builtin,
+#        file-builtin,
+#        long-builtin,
+#        raw_input-builtin,
+#        reduce-builtin,
+#        standarderror-builtin,
+#        unicode-builtin,
+#        xrange-builtin,
+#        coerce-method,
+#        delslice-method,
+#        getslice-method,
+#        setslice-method,
+#        no-absolute-import,
+#        old-division,
+#        dict-iter-method,
+#        dict-view-method,
+#        next-method-called,
+#        metaclass-assignment,
+#        indexing-exception,
+#        raising-string,
+#        reload-builtin,
+#        oct-method,
+#        hex-method,
+#        nonzero-method,
+#        cmp-method,
+#        input-builtin,
+#        round-builtin,
+#        intern-builtin,
+#        unichr-builtin,
+#        map-builtin-not-iterating,
+#        zip-builtin-not-iterating,
+#        range-builtin-not-iterating,
+#        filter-builtin-not-iterating,
+#        using-cmp-argument,
+#        eq-without-hash,
+#        div-method,
+#        idiv-method,
+#        rdiv-method,
+#        exception-message-attribute,
+#        invalid-str-codec,
+#        sys-max-int,
+#        bad-python3-import,
+#        deprecated-string-function,
+#        deprecated-str-translate-call,
+#        deprecated-itertools-function,
+#        deprecated-types-field,
+#        next-method-defined,
+#        dict-items-not-iterating,
+#        dict-keys-not-iterating,
+#        dict-values-not-iterating
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=88
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/pytest26_extra_requirements.txt
+++ b/pytest26_extra_requirements.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running pytest with python2.6 here:
+# NOTE: If your pytests need ansible, use the requirements from
+# ansible26_requirements.txt, either by listing it like this:
+-ransible26_requirements.txt

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+
+# Write extra requirements for running pytest here:
+# NOTE: for python 2.6 environments, use pytest26_extra_requirements.txt
+# if your pytests need ansible, add ansible here
+ansible

--- a/tests/setup_module_utils.sh
+++ b/tests/setup_module_utils.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+fi
+
+if [ ! -d "${1:-}" ] ; then
+    echo Either ansible is not installed, or there is no ansible/module_utils
+    echo in $1 - Skipping
+    exit 0
+fi
+
+if [ ! -d "${2:-}" ] ; then
+    echo Role has no module_utils - Skipping
+    exit 0
+fi
+
+# we need absolute path for $2
+absmoddir=$( readlink -f "$2" )
+
+# clean up old links to module_utils
+for item in "$1"/* ; do
+    if lnitem=$( readlink "$item" ) && test -n "$lnitem" ; then
+        case "$lnitem" in
+            *"${2}"*) rm -f "$item" ;;
+        esac
+    fi
+done
+
+# add new links to module_utils
+for item in "$absmoddir"/* ; do
+    case "$item" in
+        *__pycache__) continue;;
+        *.pyc) continue;;
+    esac
+    bnitem=$( basename "$item" )
+    ln -s "$item" "$1/$bnitem"
+done

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: MIT
+[tox]
+envlist =
+    black, pylint, flake8, yamllint
+    py{26,27,36,37,38},
+    custom
+skipsdist = true
+skip_missing_interpreters = true
+
+[testenv]
+basepython = python3
+# List common dependencies for Python interpreters here:
+deps =
+    py{26,27,36,37,38}: pytest-cov
+    py{27,36,37,38}: pytest>=3.5.1
+    py{27,36,37,38}: -rpytest_extra_requirements.txt
+    py{26,27}: mock
+    py26: pytest
+    py26: -rpytest26_extra_requirements.txt
+
+[base]
+passenv = *
+setenv =
+    PYTHONPATH = {toxinidir}/library:{toxinidir}/module_utils
+    LC_ALL = C
+    SRC_MODULE_UTILS_DIR = {envsitepackagesdir}/ansible/module_utils
+    DEST_MODULE_UTILS_DIR = {toxinidir}/module_utils
+changedir = {toxinidir}/tests
+covtargets = --cov={toxinidir}/library --cov={toxinidir}/module_utils
+pytesttarget = unit
+whitelist_externals =
+    bash
+runpytest = {toxinidir}/.travis/runpytest.sh
+
+[testenv:py26]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.6}
+install_command =
+    pip install {opts} {packages}
+list_dependencies_command =
+    pip freeze
+basepython = python2.6
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[base]runpytest} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py26 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
+
+[testenv:py27]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
+basepython = python2.7
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[base]runpytest} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py27 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
+
+[testenv:py36]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}
+basepython = python3.6
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[base]runpytest} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py36 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
+
+[testenv:py37]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.7}
+basepython = python3.7
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[base]runpytest} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py37 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
+
+[testenv:py38]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.8}
+basepython = python3.8
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[base]runpytest} \
+         --durations=5 \
+         {[base]covtargets} \
+         --cov-report=html:htmlcov-py38 \
+         --cov-report=term \
+         {posargs} \
+         {[base]pytesttarget}
+
+[testenv:black]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:3.6}
+basepython = python3.6
+passenv = RUN_BLACK_*
+deps =
+    black
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {toxinidir}/.travis/runblack.sh --check --diff .
+
+[testenv:pylint]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
+basepython = python2.7
+passenv = RUN_PYLINT_*
+setenv =
+    {[base]setenv}
+deps =
+    ansible
+    colorama
+    pylint>=1.8.4
+    -rpylint_extra_requirements.txt
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {toxinidir}/.travis/runpylint.sh --errors-only {posargs}
+
+[testenv:flake8]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
+basepython = python2.7
+passenv = RUN_FLAKE8_*
+deps =
+    flake8>=3.5
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {toxinidir}/.travis/runflake8.sh --exclude=.venv,.tox --statistics {posargs} .
+
+[testenv:yamllint]
+deps = yamllint
+commands = yamllint .
+
+[testenv:coveralls]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}
+passenv = TRAVIS TRAVIS_*
+deps =
+    coveralls
+changedir = {[base]changedir}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {toxinidir}/.travis/runcoveralls.sh {posargs}
+
+[molecule_common]
+deps =
+    {env:LSR_ANSIBLE_DEP:ansible}
+    docker
+    molecule<3
+    selinux
+    -rmolecule_extra_requirements.txt
+runsyspycmd = {toxinidir}/.travis/runsyspycmd.sh
+
+[testenv:molecule_version]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
+deps =
+    {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[molecule_common]runsyspycmd} molecule --version
+    bash {[molecule_common]runsyspycmd} ansible --version
+
+[testenv:molecule_lint]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
+deps =
+    {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[molecule_common]runsyspycmd} \
+         molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
+
+[testenv:molecule_syntax]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
+deps =
+    {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[molecule_common]runsyspycmd} \
+         molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
+
+[testenv:molecule_test]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
+deps =
+    {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {[molecule_common]runsyspycmd} \
+         molecule test -s {env:LSR_MSCENARIO:default} {posargs}
+
+[testenv:molecule]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
+deps =
+    {[molecule_common]deps}
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    {[testenv:molecule_version]commands}
+    {[testenv:molecule_lint]commands}
+    {[testenv:molecule_syntax]commands}
+    {[testenv:molecule_test]commands}
+
+[testenv:custom]
+envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:custom}
+deps =
+    -rcustom_requirements.txt
+passenv = *
+whitelist_externals =
+    {[base]whitelist_externals}
+commands =
+    bash {toxinidir}/.travis/custom.sh
+
+[pytest]
+addopts = -rxs
+
+[flake8]
+show_source = true
+max-line-length = 88
+ignore = E402,W503
+
+[pylint]
+max-line-length = 88
+disable = wrong-import-position
+
+[pycodestyle]
+max-line-length = 88
+
+[travis]
+python =
+  2.6: py26,custom
+  2.7: py27,flake8,pylint,custom
+  3.5: coveralls,custom
+  3.6: py36,black,yamllint,custom
+  3.7: py37,custom
+  3.8: py38,custom


### PR DESCRIPTION
use tox as the main task/test runner
add support for local customizations like
- no molecule test for centos6
- relaxed yamllint testing
- no flake8 or black testing
- add pytest as a dep for pylint
- setup_module_utils for unit testing