### PR TITLE
Determine too_large_size dynamically

### DIFF
--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -8,7 +8,9 @@
     invalid_disks:
       - '/non/existent/disk'
     invalid_size: 'xyz GiB'
-    too_large_size: '500 GiB'
+    unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
+    too_large_size: '{{ (unused_disk_subfact.sectors|int + 1) *
+                        unused_disk_subfact.sectorsize|int }}'
 
   tasks:
     - include_role:


### PR DESCRIPTION
To test proper error handling the test playbook needs to attempt to create a pool that is too large for the underlying device. What is "too large" depends on the device though. We should not assume that the tests will be run against a VM with disks created by the provisioning script with the expected size, tests can be executed in any environment, like on a machine with a number of big
physical disks.

tests_lvm_errors has been using a fixed size as the "too large" size, making it fail in an environment with disks larger than that. Make it determine the size dynamically instead. The "too large" size is now just one sector more than the size of the disk that is going to be used for the test.

Reported by @yizhanglinux.