### PR TITLE
Avoid using ansible_failed_task in rescue blocks

### DIFF
--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -26,19 +26,16 @@
                 disks: ['/dev/surelyidonotexist']
                 mount_point: "{{ mount_location }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         # the following does not work properly,
         # blivet_output.failed is false.
@@ -114,19 +111,16 @@
                 fs_type: 'ext3'
                 disks: "{{ unused_disks }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     - name: Verify the output
       assert:
@@ -158,19 +152,16 @@
                 fs_type: 'ext3'
                 disks: "{{ unused_disks }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     - name: Verify the output
       assert:
@@ -212,19 +203,16 @@
                 disks: "{{ unused_disks }}"
                 type: partition
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output
           assert:
@@ -244,19 +232,16 @@
                 disks: "{{ unused_disks }}"
                 type: lvm
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output
           assert:

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -37,19 +37,16 @@
                     size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     # the following does not work properly
     # - debug:
@@ -78,19 +75,16 @@
                     size: "{{ invalid_size }}"
                     mount_point: "{{ mount_location1 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     # the following does not work properly
     # - name: Verify the output
@@ -114,19 +108,16 @@
                     size: "{{ too_large_size }}"
                     mount_point: "{{ mount_location1 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     # the following does not work properly
     # - name: Verify the output
@@ -150,19 +141,16 @@
                     size: "{{ too_large_size }}"
                     mount_point: "{{ mount_location1 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     # the following does not work properly
     # - name: Verify the output
@@ -186,19 +174,16 @@
                     size: "{{ too_large_size }}"
                     mount_point: "{{ mount_location1 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     # the following does not work properly
     # - name: Verify the output
@@ -221,19 +206,16 @@
                 size: "{{ volume1_size }}"
                 mount_point: "{{ mount_location1 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     # the following does not work properly
     # - name: Verify the output
@@ -347,19 +329,16 @@
                     fs_type: 'ext3'
                     size: '1g'
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output
           assert:
@@ -401,19 +380,16 @@
                 disks: "{{ unused_disks }}"
                 type: lvm
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output
           assert:
@@ -435,19 +411,16 @@
                 disks:
                   - "{{ unused_disks[0] }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
     - name: Verify the output
       assert:


### PR DESCRIPTION
`ansible_failed_task` can contain unexpanded Jinja2 templates with variable references that were valid when the task failed, but not valid anymore when using the variable in the `rescue` block. In this case the problem is with task names (`.name`) that contain references to `storage_provider`. Unfortunately this completely prevents using `ansible_failed_task` even if not using the problematic attribute. Other attribute could have been used if this were not the case, like `.tags`, but until https://github.com/ansible/ansible/issues/49942 is fixed, it is better to avoid using `ansible_failed_task` and use the only other special variable describing the failed task: `ansible_failed_result`.

Eliminate the previous workaround to set storage_provider on the tasks that expand `ansible_failed_task` and use `ansible_failed_result` with a special value of `msg` instead. This has a disadvantage of having to use a special `msg` with the `fail` module, while usually it is just a free-form message. The `fail` module does not set another attribute of the result that could be used though, and it is cleaner than the previous workaround.