### PR TITLE
Correctly Manage Swap Volumes

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -549,7 +549,7 @@ class BlivetPartitionPool(BlivetPool):
 
     def _create(self):
         if self._device.format.type != "disklabel" or \
-           self._device.format.label_type != disklabel_type:
+           (disklabel_type and self._device.format.label_type != disklabel_type):
             if safe_mode:
                 raise BlivetAnsibleError("cannot remove existing formatting and/or devices on disk '%s' "
                                          "(pool '%s') in safe mode" % (self._device.name, self._pool['name']))

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -753,6 +753,22 @@ def update_fstab_identifiers(b, pools, volumes):
                 device.format.setup()
 
 
+def activate_swaps(b, pools, volumes):
+    """ Activate all swaps specified as present. """
+    all_volumes = volumes[:]
+    for pool in pools:
+        if not pool['present']:
+            continue
+
+        all_volumes += pool['volumes']
+
+    for volume in all_volumes:
+        if volume['state'] == 'present':
+            device = b.devicetree.resolve_device(volume['_mount_id'])
+            if device.format.type == 'swap':
+                device.format.setup()
+
+
 def run_module():
     # available arguments/parameters that a user can pass
     module_args = dict(
@@ -860,6 +876,7 @@ def run_module():
             result['actions'] = [action_dict(a) for a in actions]
 
     update_fstab_identifiers(b, module.params['pools'], module.params['volumes'])
+    activate_swaps(b, module.params['pools'], module.params['volumes'])
 
     result['mounts'] = get_mount_info(module.params['pools'], module.params['volumes'], actions, fstab)
     result['leaves'] = [d.path for d in b.devicetree.leaves]

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -131,10 +131,10 @@
 #
 - name: manage mounts to match the specified state
   mount:
-    src: "{{ mount_info['src'] if mount_info['state'] == 'mounted' else omit }}"
+    src: "{{ mount_info['src']|default(omit) }}"
     path: "{{ mount_info['path'] }}"
-    fstype: "{{ mount_info['fstype'] if mount_info['state'] == 'mounted' else omit }}"
-    opts: "{{ mount_info['opts'] if mount_info['state'] == 'mounted' else omit }}"
+    fstype: "{{ mount_info['fstype']|default(omit) }}"
+    opts: "{{ mount_info['opts']|default(omit) }}"
     state: "{{ mount_info['state'] }}"
   loop: "{{ blivet_output.mounts }}"
   loop_control:

--- a/tests/test-verify-volume-fstab.yml
+++ b/tests/test-verify-volume-fstab.yml
@@ -3,20 +3,21 @@
   set_fact:
     storage_test_fstab_id_matches: "{{ storage_test_fstab.stdout_lines|map('regex_search', '^' + storage_test_volume._mount_id + ' ')|select('string')|list }}"
     storage_test_fstab_mount_point_matches: "{{ storage_test_fstab.stdout_lines|map('regex_search', ' +' + storage_test_volume.mount_point + ' +')|select('string')|list if storage_test_volume.mount_point else [] }}"
-    storage_test_fstab_expected_matches: "{{ 1 if (_storage_test_volume_present and storage_test_volume.mount_point) else 0 }}"
+    storage_test_fstab_expected_id_matches: "{{ 1 if (_storage_test_volume_present and (storage_test_volume.mount_point or storage_test_volume.fs_type == 'swap')) else 0 }}"
+    storage_test_fstab_expected_mount_point_matches: "{{ 1 if (_storage_test_volume_present and storage_test_volume.mount_point) else 0 }}"
 
 # device id
 - name: Verify that the device identifier appears in /etc/fstab
   assert:
-    that: "{{ storage_test_fstab_id_matches|length == storage_test_fstab_expected_matches|int }}"
+    that: "{{ storage_test_fstab_id_matches|length == storage_test_fstab_expected_id_matches|int }}"
     msg: "Expected device identifier not found in /etc/fstab."
   when: _storage_test_volume_present
 
 # mount point
 - name: Verify the fstab mount point
   assert:
-    that: "{{ storage_test_fstab_mount_point_matches|length == storage_test_fstab_expected_matches|int }}"
-    msg: "Expected number ({{ storage_test_fstab_expected_matches }}) of entries with volume '{{ storage_test_volume.name }}' mount point not found in /etc/fstab."
+    that: "{{ storage_test_fstab_mount_point_matches|length == storage_test_fstab_expected_mount_point_matches|int }}"
+    msg: "Expected number ({{ storage_test_fstab_expected_mount_point_matches }}) of entries with volume '{{ storage_test_volume.name }}' mount point not found in /etc/fstab."
 
 # todo: options
 
@@ -24,4 +25,5 @@
   set_fact:
     storage_test_fstab_id_matches: null
     storage_test_fstab_mount_point_matches: null
-    storage_test_fstab_expected_matches: null
+    storage_test_fstab_expected_id_matches: null
+    storage_test_fstab_expected_mount_point_matches: null

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -6,6 +6,7 @@
     storage_test_mount_device_matches: "{{ ansible_mounts|json_query('[?device==`\"{}\"`]'.format(storage_test_volume._device))}}"
     storage_test_mount_point_matches: "{{ ansible_mounts|json_query('[?mount==`\"{}\"`]'.format(storage_test_volume.mount_point))}}"
     storage_test_mount_expected_match_count: "{{ 1 if _storage_test_volume_present and storage_test_volume.mount_point else 0 }}"
+    storage_test_swap_expected_matches: "{{ 1 if _storage_test_volume_present and storage_test_volume.fs_type == 'swap' else 0 }}"
 
 #
 # Verify mount presence.
@@ -34,6 +35,24 @@
   when: storage_test_mount_expected_match_count|int == 1
 
 #
+# Verify swap status.
+#
+- command: realpath "{{ storage_test_volume._device }}"
+  register: storage_test_sys_node
+  when: storage_test_volume.fs_type == "swap"
+
+- name: Gather swap info
+  command: cat /proc/swaps
+  register: storage_test_swaps
+  when: storage_test_volume.fs_type == "swap"
+
+- name: Verify swap status
+  assert:
+    that: "{{ storage_test_swaps.stdout|regex_findall('^' + storage_test_sys_node.stdout + ' ', multiline=True)|list|length|int == storage_test_swap_expected_matches|int }}"
+    msg: "Unexpected number of matching active swaps"
+  when: storage_test_volume.fs_type == "swap"
+
+#
 # Verify mount options.
 #
 
@@ -42,3 +61,6 @@
     storage_test_mount_device_matches: null
     storage_test_mount_point_matches: null
     storage_test_mount_expected_match_count: null
+    storage_test_swap_expected_matches: null
+    storage_test_sys_node: null
+    storage_test_swaps: null

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -1,0 +1,91 @@
+---
+- hosts: all
+  become: true
+  vars:
+    storage_safe_mode: false
+    mount_location: '/opt/test'
+    volume_size: '5g'
+
+  tasks:
+    - include_role:
+        name: storage
+
+    - include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "{{ volume_size }}"
+        max_return: 1
+
+    - name: Create a disk device with swap
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            disks: "{{ unused_disks }}"
+            fs_type: 'swap'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Change the disk device file system type to ext3
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            mount_point: "{{ mount_location }}"
+            fs_type: ext3
+            disks: "{{ unused_disks }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Repeat the previous invocation to verify idempotence
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            mount_point: "{{ mount_location }}"
+            fs_type: ext3
+            disks: "{{ unused_disks }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Change it back to swap
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            disks: "{{ unused_disks }}"
+            fs_type: 'swap'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Repeat the previous invocation to verify idempotence
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            disks: "{{ unused_disks }}"
+            fs_type: 'swap'
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Clean up
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+            state: absent
+
+    - include_tasks: verify-role-results.yml

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -3,4 +3,4 @@ blivet_package_list:
   - python-blivet3
   - libblockdev-dm
   - libblockdev-lvm
-  - libblockdev-part
+  - libblockdev-swap

--- a/vars/CentOS-8.yml
+++ b/vars/CentOS-8.yml
@@ -2,4 +2,4 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-dm
   - libblockdev-lvm
-  - libblockdev-part
+  - libblockdev-swap

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -2,4 +2,4 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-dm
   - libblockdev-lvm
-  - libblockdev-part
+  - libblockdev-swap

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -3,4 +3,4 @@ blivet_package_list:
   - python-blivet3
   - libblockdev-dm
   - libblockdev-lvm
-  - libblockdev-part
+  - libblockdev-swap

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -2,4 +2,4 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-dm
   - libblockdev-lvm
-  - libblockdev-part
+  - libblockdev-swap


### PR DESCRIPTION
This should address #66.

It changes less than #68 did, since some of those changes were based on incorrect assertions, namely that the mount module doesn't support removing specific swap entries from /etc/fstab.