### PR TITLE
Avoid using ansible_failed_task in rescue blocks second round

### DIFF
--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -62,19 +62,16 @@
                 type: disk
                 disks: "{{ unused_disks }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output of the duplicate volumes test
           assert:

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -239,19 +239,16 @@
                 type: lvm
                 disks: "{{ unused_disks }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output of the duplicate pools test
           assert:
@@ -280,19 +277,16 @@
                     size: "{{ volume2_size }}"
                     mount_point: "{{ mount_location2 }}"
 
-        - name: UNREACH
+        - name: unreachable task
           fail:
-            msg: "this should be unreachable"
+            msg: UNREACH
 
       rescue:
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_task.name != 'UNREACH'
+              - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
-          vars:
-            # Ugh! needed to expand ansible_failed_task
-            storage_provider: blivet
 
         - name: Verify the output of the duplicate volumes test
           assert:


### PR DESCRIPTION
Signed-off-by: Yi Zhang <yi.zhang@redhat.com>