### PR TITLE
Update supported Fedora versions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,6 +7,6 @@ galaxy_info:
   min_ansible_version: 2.5
   platforms:
     - name: Fedora
-      versions: [ 29, 30 ]
+      versions: [ 31, 32 ]
     - name: EL
       versions: [ 7, 8 ]


### PR DESCRIPTION
Will also serve to rerun CI after the recent merges.