### PR TITLE
tests: add misc tests for pull/125

### DIFF
--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -1,0 +1,225 @@
+---
+- hosts: all
+  become: true
+  vars:
+    storage_safe_mode: false
+    mount_location: '/opt/test1'
+    volume_group_size: '5g'
+    volume1_size: '4g'
+    unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
+    too_large_size: '{{ (unused_disk_subfact.sectors|int + 1) *
+                        unused_disk_subfact.sectorsize|int }}'
+
+  tasks:
+    - include_role:
+        name: storage
+
+    - include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "{{ volume_group_size }}"
+        max_return: 1
+
+    - name: Test creating ext4 filesystem with valid parameter "-Fb 4096"
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                fs_type: 'ext4'
+                size: "{{ volume1_size }}"
+                fs_create_options: '-Fb 4096'
+                mount_point: "{{ mount_location }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the volume group created above
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Test for correct handling of invalid parameter when creating ext4 filesystem
+      block:
+        - name: Try to create ext4 filesystem with invalid parameter "-Fb 512"
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    fs_type: 'ext4'
+                    size: "{{ volume1_size }}"
+                    fs_create_options: '-Fb 512'
+                    mount_point: "{{ mount_location }}"
+
+        - name: Unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output when creating ext4 filesystem with invalid parameter "-Fb 512"
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('Failed to commit changes to disk.*FSError.*format failed: 1.*/dev/mapper/foo-test1') and
+                   not blivet_output.changed"
+            msg: "Unexpected behavior when creating ext4 filesystem whith invalid parameter"
+
+    - name: Remove the volume group created above
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - name: Create one LVM logical volume with "{{ volume1_size }}" under one volume group
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                fs_type: 'ext4'
+                size: "{{ volume1_size }}"
+                mount_point: "{{ mount_location }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Test for correct handling resize large size
+      block:
+        - name: Resizing with one large value which large than disk's size
+          include_role:
+            name: storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    fs_type: 'ext4'
+                    size: "{{ too_large_size }}"
+                    mount_point: "{{ mount_location }}"
+
+        - name: Unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output when resizing with large size
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('volume.*foo-test1.*cannot be resized from.*to.*') and
+                   not blivet_output.changed"
+            msg: "Unexpected behavior when resizing with large size"
+
+    - name: Remove the volume group created above
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: lvm
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - name: Create one partition on one disk
+      include_role:
+        name: storage
+      vars:
+        storage_pools:
+          - name: foo
+            type: partition
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                type: partition
+                fs_type: 'ext4'
+                mount_point: "{{ mount_location }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Test setting up disk volume will remove the partition create above
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: foo
+            type: disk
+            disks: "{{ unused_disks }}"
+            fs_type: 'ext4'
+            fs_create_options: '-F'
+            mount_point: "{{ mount_location }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the disk volume created above
+      include_role:
+        name: storage
+      vars:
+        storage_volumes:
+          - name: foo
+            type: disk
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - name: Test for correct handling of mounting a non-mountable formatiing type
+      block:
+        - name: Try to mount swap filesystem to "{{  mount_location }}"
+          include_role:
+              name: storage
+          vars:
+            storage_volumes:
+              - name: test1
+                type: disk
+                disks: "{{ unused_disks }}"
+                fs_type: 'swap'
+                mount_point: "{{ mount_location }}"
+
+        - name: Unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output when mount swap filesystem to "{{  mount_location }}"
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg|regex_search('volume.*test1.*has a mount point but no mountable file system') and
+                   not blivet_output.changed"
+            msg: "Unexpected behavior when mount swap filesystem"


### PR DESCRIPTION
**note:** This should be merged after pull/125 merged

Add valid/invalid fs_create_options tests
'Fix passing of fs create options to blivet.'

Add unresizable test
'Fail on request to resize unresizable fs.'

Add tests for handling remove patition when setting up disk volume
'Remove partitions etc as needed when setting up disk volume.'

Add tests for mounting swap to one mount location
'Fail w/ error if mount specified w/o mountable fs.'

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>