### PR TITLE
Be smarter in choosing expected partition name.

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -556,7 +556,11 @@ class BlivetPartitionVolume(BlivetVolume):
         return self._device.raw_device.type == 'partition'
 
     def _get_device_id(self):
-        return self._blivet_pool._disks[0].name + '1'
+        device_id = None
+        if self._blivet_pool._disks[0].partitioned and len(self._blivet_pool._disks[0].children) == 1:
+            device_id = self._blivet_pool._disks[0].children[0].name
+
+        return device_id
 
     def _resize(self):
         pass


### PR DESCRIPTION
BlivetVolume._get_device_id is only used to look up pre-existing
volumes, so we don't have to try too hard to guess it by name.
We can just see if the disk has a single partition and, if so,
return the name of that partition.

Fixes: #141