### PR TITLE
add 'disks_needed: 3' to tests_raid_volume_options.yml

### DIFF
--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -13,6 +13,7 @@
     - include_tasks: get_unused_disk.yml
       vars:
         max_return: 3
+        disks_needed: 3
 
     - name: Create a RAID0 device mounted on "{{ mount_location }}"
       include_role:


### PR DESCRIPTION
The test case should be fail earlier if no enough disks
Fixes: linux-system-roles#112

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>