### PR TITLE
Update condition in tests_misc.yml

### DIFF
--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -139,7 +139,7 @@
         - name: Verify the output when resizing with large size
           assert:
             that: "blivet_output.failed and
-                   blivet_output.msg|regex_search('volume.*foo-test1.*cannot be resized from.*to.*') and
+                   blivet_output.msg|regex_search('volume.*test1.*cannot be resized to.*') and
                    not blivet_output.changed"
             msg: "Unexpected behavior when resizing with large size"
 


### PR DESCRIPTION
With merging of #97 the error message when resizing a volume to a too large size got changed. Account for that in the test.