### PR TITLE
Disallow toggling encryption in safe mode

### DIFF
--- a/tests/create-test-file.yml
+++ b/tests/create-test-file.yml
@@ -1,0 +1,13 @@
+# Create a file to be checked that it still exists and no data loss has occured.
+# To use:
+# - set testfile to a path under the mountpoint being tested
+# - include this file (create-test-file.yml) before executing the
+#   operation to be tested
+# - execute the operation that could potentially result in a loss of
+#   data in the filesystem where testfile is located
+# - include verify-data-preservation.yml
+
+- name: create a file
+  file:
+    path: "{{ testfile }}"
+    state: touch

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -91,6 +91,15 @@
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
 
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove existing
+                   formatting.*in safe mode due to encryption removal')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing pool in safe mode"
+
     - import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer
@@ -132,6 +141,15 @@
             that:
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove existing
+                   formatting.*in safe mode due to adding encryption')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing pool in safe mode"
 
     - import_tasks: verify-data-preservation.yml
 

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -2,7 +2,6 @@
 - hosts: all
   become: true
   vars:
-    storage_safe_mode: false
     mount_location: '/opt/test1'
     testfile: "{{ mount_location }}/quux"
     volume_size: '5g'
@@ -73,7 +72,6 @@
           include_role:
             name: linux-system-roles.storage
           vars:
-            storage_safe_mode: true
             storage_volumes:
               - name: foo
                 type: disk
@@ -106,6 +104,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_volumes:
           - name: foo
             type: disk
@@ -124,7 +123,6 @@
           include_role:
             name: linux-system-roles.storage
           vars:
-            storage_safe_mode: true
             storage_volumes:
               - name: foo
                 type: disk
@@ -157,6 +155,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_volumes:
           - name: foo
             type: disk
@@ -177,6 +176,7 @@
           include_role:
             name: linux-system-roles.storage
           vars:
+            storage_safe_mode: false
             storage_pools:
               - name: foo
                 type: partition
@@ -210,6 +210,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: partition
@@ -228,6 +229,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: partition
@@ -261,6 +263,7 @@
           include_role:
             name: linux-system-roles.storage
           vars:
+            storage_safe_mode: false
             storage_pools:
               - name: foo
                 type: partition
@@ -291,6 +294,7 @@
           include_role:
             name: linux-system-roles.storage
           vars:
+            storage_safe_mode: false
             storage_pools:
               - name: foo
                 type: lvm
@@ -323,6 +327,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: lvm
@@ -347,7 +352,6 @@
           include_role:
             name: linux-system-roles.storage
           vars:
-            storage_safe_mode: true
             storage_pools:
               - name: foo
                 type: lvm
@@ -376,6 +380,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: lvm
@@ -397,7 +402,6 @@
           include_role:
             name: linux-system-roles.storage
           vars:
-            storage_safe_mode: true
             storage_pools:
               - name: foo
                 type: lvm
@@ -426,6 +430,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: lvm

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -96,7 +96,7 @@
                    |regex_search('cannot remove existing
                    formatting.*in safe mode due to encryption removal')
                    and not blivet_output.changed"
-            msg: "Unexpected behavior w/ existing pool in safe mode"
+            msg: "Unexpected behavior w/ existing filesystem in safe mode"
 
     - import_tasks: verify-data-preservation.yml
 
@@ -147,7 +147,7 @@
                    |regex_search('cannot remove existing
                    formatting.*in safe mode due to adding encryption')
                    and not blivet_output.changed"
-            msg: "Unexpected behavior w/ existing pool in safe mode"
+            msg: "Unexpected behavior w/ existing filesystem in safe mode"
 
     - import_tasks: verify-data-preservation.yml
 
@@ -374,6 +374,15 @@
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
 
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove existing
+                   formatting.*in safe mode due to encryption removal')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing volume in safe mode"
+
     - import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer
@@ -423,6 +432,15 @@
             that:
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove existing
+                   formatting.*in safe mode due to adding encryption')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing volume in safe mode"
 
     - import_tasks: verify-data-preservation.yml
 

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -4,6 +4,7 @@
   vars:
     storage_safe_mode: false
     mount_location: '/opt/test1'
+    testfile: "{{ mount_location }}/quux"
     volume_size: '5g'
 
   tasks:
@@ -64,6 +65,34 @@
 
     - include_tasks: verify-role-results.yml
 
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Remove the encryption layer
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_safe_mode: true
+            storage_volumes:
+              - name: foo
+                type: disk
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                encryption: false
+                encryption_password: 'yabbadabbadoo'
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - import_tasks: verify-data-preservation.yml
+
     - name: Remove the encryption layer
       include_role:
         name: linux-system-roles.storage
@@ -77,6 +106,34 @@
             encryption_password: 'yabbadabbadoo'
 
     - include_tasks: verify-role-results.yml
+
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Add encryption to the volume
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_safe_mode: true
+            storage_volumes:
+              - name: foo
+                type: disk
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                encryption: true
+                encryption_password: 'yabbadabbadoo'
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume
       include_role:
@@ -264,6 +321,39 @@
 
     - include_tasks: verify-role-results.yml
 
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Remove the encryption layer
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+                    encryption: false
+                    encryption_password: 'yabbadabbadoo'
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - import_tasks: verify-data-preservation.yml
+
     - name: Remove the encryption layer
       include_role:
         name: linux-system-roles.storage
@@ -280,6 +370,39 @@
                 encryption_password: 'yabbadabbadoo'
 
     - include_tasks: verify-role-results.yml
+
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Add encryption to the volume
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+                    encryption: true
+                    encryption_password: 'yabbadabbadoo'
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume
       include_role:

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -225,6 +225,46 @@
 
     - include_tasks: verify-role-results.yml
 
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Remove the encryption layer
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: partition
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    type: partition
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+                    encryption: false
+                    encryption_password: 'yabbadabbadoo'
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove existing
+                   formatting.*in safe mode due to encryption removal')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing filesystem in safe mode"
+
+    - import_tasks: verify-data-preservation.yml
+
     - name: Remove the encryption layer
       include_role:
         name: linux-system-roles.storage
@@ -243,6 +283,48 @@
                 encryption_password: 'yabbadabbadoo'
 
     - include_tasks: verify-role-results.yml
+
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Add encryption to the volume
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: partition
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    type: partition
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+                    encryption: true
+                    encryption_password: 'yabbadabbadoo'
+
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove existing
+                   formatting.*in safe mode due to adding encryption')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing volume in safe mode"
+
+    - import_tasks: verify-data-preservation.yml
 
     - name: Test key file handling
       block:

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -174,6 +174,15 @@
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
 
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove and recreate existing
+                   pool.*in safe mode')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing pool in safe mode"
+
     - import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the pool

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -121,6 +121,15 @@
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
 
+        - name: Verify the output of the safe_mode test
+          assert:
+            that: "blivet_output.failed and
+                   blivet_output.msg
+                   |regex_search('cannot remove and recreate existing
+                   pool.*in safe mode')
+                   and not blivet_output.changed"
+            msg: "Unexpected behavior w/ existing pool in safe mode"
+
     - import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -5,6 +5,8 @@
     storage_safe_mode: false
     mount_location: '/opt/test1'
     mount_location_2: '/opt/test2'
+    testfile: "{{ mount_location }}/quux"
+    testfile_location_2: "{{ mount_location_2 }}/quux"
     volume_size: '5g'
 
   tasks:
@@ -92,6 +94,37 @@
             state: absent
           changed_when: false
 
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Remove the encryption layer
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                encryption: false
+                encryption_password: 'yabbadabbadoo'
+                volumes:
+                  - name: test1
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - import_tasks: verify-data-preservation.yml
+
     - name: Remove the encryption layer
       include_role:
         name: linux-system-roles.storage
@@ -109,7 +142,41 @@
 
     - include_tasks: verify-role-results.yml
 
-    - name: Add encryption to the volume
+    - import_tasks: create-test-file.yml
+
+    - name: Test for correct handling of safe_mode
+      block:
+        - name: Add encryption to the pool
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_safe_mode: true
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                encryption: true
+                encryption_password: 'yabbadabbadoo'
+                encryption_luks_version: luks1
+                encryption_key_size: 512
+                encryption_cipher: 'serpent-xts-plain64'
+                volumes:
+                  - name: test1
+                    mount_point: "{{ mount_location }}"
+                    size: 4g
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - import_tasks: verify-data-preservation.yml
+
+    - name: Add encryption to the pool
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -129,6 +196,8 @@
 
     - include_tasks: verify-role-results.yml
 
+    - import_tasks: create-test-file.yml
+
     - name: Change the mountpoint, leaving encryption in place
       include_role:
         name: linux-system-roles.storage
@@ -143,6 +212,10 @@
               - name: test1
                 mount_point: "{{ mount_location_2 }}"
                 size: 4g
+
+    - import_tasks: verify-data-preservation.yml
+      vars:
+        testfile: "{{ testfile_location_2 }}"
 
     - include_tasks: verify-role-results.yml
 

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -2,7 +2,6 @@
 - hosts: all
   become: true
   vars:
-    storage_safe_mode: false
     mount_location: '/opt/test1'
     mount_location_2: '/opt/test2'
     testfile: "{{ mount_location }}/quux"
@@ -102,7 +101,6 @@
           include_role:
             name: linux-system-roles.storage
           vars:
-            storage_safe_mode: true
             storage_pools:
               - name: foo
                 type: lvm
@@ -129,6 +127,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: lvm
@@ -150,7 +149,6 @@
           include_role:
             name: linux-system-roles.storage
           vars:
-            storage_safe_mode: true
             storage_pools:
               - name: foo
                 type: lvm
@@ -189,6 +187,7 @@
       include_role:
         name: linux-system-roles.storage
       vars:
+        storage_safe_mode: false
         storage_pools:
           - name: foo
             type: lvm

--- a/tests/verify-data-preservation.yml
+++ b/tests/verify-data-preservation.yml
@@ -1,0 +1,19 @@
+# Verify that a file still exists and no data loss has occured.
+# To use:
+# - set testfile to a path under the mountpoint being tested
+# - include create-test-file.yml before executing the operation to be
+#   tested
+# - execute the operation that could potentially result in a loss of
+#   data in the filesystem where testfile is located
+# - include this file (verify-data-preservation.yml)
+
+- name: stat the file
+  stat:
+    path: "{{ testfile }}"
+  register: stat_r
+
+- name: assert file presence
+  assert:
+    that:
+      stat_r.stat.isreg is defined and stat_r.stat.isreg
+    msg: "data lost!"


### PR DESCRIPTION
Toggling encryption is (currently) a destructive operation, and this fact is quite nonintuitive and possibly dangerous. Let it be covered by the storage_safe_mode flag, just as with other operations that cause data loss (except for explicit removal).