### PR TITLE
use tox for ansible-lint instead of molecule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,7 @@
 ---
 skip_list:
 - '106'
+- '204'  # Lines should be no longer than 160 chars
 - '208'
 - '306'
 - '403'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,7 @@ driver:
   name: docker
 lint:
   name: yamllint
+  enabled: false
   options:
     config-file: .yamllint.yml
 platforms:
@@ -18,6 +19,7 @@ provisioner:
   name: ansible
   log: true
   lint:
+    enabled: false
     name: ansible-lint
   playbooks:
     converge: ../../tests/tests_default.yml
@@ -34,3 +36,4 @@ verifier:
   name: testinfra
   lint:
     name: flake8
+    enabled: false

--- a/tests/test-verify-volume-md.yml
+++ b/tests/test-verify-volume-md.yml
@@ -11,15 +11,15 @@
 
     # pre-chew regex search patterns 
     - set_fact:
-        storage_test_md_active_devices_re: "{{('Active Devices : ' ~ storage_test_volume.raid_device_count ~ '\n')|regex_escape()}}"
+        storage_test_md_active_devices_re: "{{ ('Active Devices : ' ~ storage_test_volume.raid_device_count ~ '\n')|regex_escape() }}"
       when: storage_test_volume.raid_device_count is defined
 
     - set_fact:
-        storage_test_md_spare_devices_re: "{{('Spare Devices : ' ~ storage_test_volume.raid_spare_count ~ '\n')|regex_escape()}}"
+        storage_test_md_spare_devices_re: "{{ ('Spare Devices : ' ~ storage_test_volume.raid_spare_count ~ '\n')|regex_escape() }}"
       when: storage_test_volume.raid_spare_count is defined
 
     - set_fact:
-        storage_test_md_metadata_version_re: "{{('Version : ' ~ storage_test_volume.raid_metadata_version ~ '\n')|regex_escape()}}"
+        storage_test_md_metadata_version_re: "{{ ('Version : ' ~ storage_test_volume.raid_metadata_version ~ '\n')|regex_escape() }}"
       when: storage_test_volume.raid_metadata_version is defined
 
     - name: check RAID active devices count

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -11,8 +11,8 @@
   set_fact:
     # json_query(...) used instead of "|selectattr('device', 'equalto', storage_test_volume._device)|list"
     # as that expression wouldn't work with Jinja versions <2.8
-    storage_test_mount_device_matches: "{{ ansible_mounts|json_query('[?device==`\"{}\"`]'.format(storage_test_device_path))}}"
-    storage_test_mount_point_matches: "{{ ansible_mounts|json_query('[?mount==`\"{}\"`]'.format(storage_test_volume.mount_point))}}"
+    storage_test_mount_device_matches: "{{ ansible_mounts|json_query('[?device==`\"{}\"`]'.format(storage_test_device_path)) }}"
+    storage_test_mount_point_matches: "{{ ansible_mounts|json_query('[?mount==`\"{}\"`]'.format(storage_test_volume.mount_point)) }}"
     storage_test_mount_expected_match_count: "{{ 1 if _storage_test_volume_present and storage_test_volume.mount_point and storage_test_volume.mount_point.startswith('/') else 0 }}"
     storage_test_swap_expected_matches: "{{ 1 if _storage_test_volume_present and storage_test_volume.fs_type == 'swap' else 0 }}"
 

--- a/tests/verify-pool-md.yml
+++ b/tests/verify-pool-md.yml
@@ -10,15 +10,15 @@
 
     # pre-chew regex search patterns
     - set_fact:
-        storage_test_md_active_devices_re: "{{('Active Devices : ' ~ storage_test_pool.raid_device_count ~ '\n')|regex_escape()}}"
+        storage_test_md_active_devices_re: "{{ ('Active Devices : ' ~ storage_test_pool.raid_device_count ~ '\n')|regex_escape() }}"
       when: storage_test_pool.raid_device_count is defined
 
     - set_fact:
-        storage_test_md_spare_devices_re: "{{('Spare Devices : ' ~ storage_test_pool.raid_spare_count ~ '\n')|regex_escape()}}"
+        storage_test_md_spare_devices_re: "{{ ('Spare Devices : ' ~ storage_test_pool.raid_spare_count ~ '\n')|regex_escape() }}"
       when: storage_test_pool.raid_spare_count is defined
 
     - set_fact:
-        storage_test_md_metadata_version_re: "{{('Version : ' ~ storage_test_pool.raid_metadata_version ~ '\n')|regex_escape()}}"
+        storage_test_md_metadata_version_re: "{{ ('Version : ' ~ storage_test_pool.raid_metadata_version ~ '\n')|regex_escape() }}"
       when: storage_test_pool.raid_metadata_version is defined
 
     - name: check RAID active devices count


### PR DESCRIPTION
Deprecate the use of molecule for linting.  Use tox for ansible-lint.
The next step will be to remove the ansible-lint dependency from
the molecule environments.