### PR TITLE
drop localhost from tests_deps.yml

### DIFF
--- a/tests/tests_deps.yml
+++ b/tests/tests_deps.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all localhost
+- hosts: all
   become: true
 
   tasks:


### PR DESCRIPTION
We do not need to check the deps on localhost.  This is causing
test failures in the staging environment (which will soon become
the new production environment) due to the way we test now with
ANSIBLE_ROLES_PATH environment variable instead of the tests/roles
role symlink
