### PR TITLE
remove include_vars, use public: true to export role vars, defaults

### DIFF
--- a/tests/run_blivet.yml
+++ b/tests/run_blivet.yml
@@ -1,7 +1,4 @@
 ---
-- include_vars:
-    file: roles/linux-system-roles.storage/defaults/main.yml
-
 - name: test lvm and xfs package deps
   blivet:
     packages_only: "{{ packages_only }}"

--- a/tests/tests_deps.yml
+++ b/tests/tests_deps.yml
@@ -5,6 +5,7 @@
   tasks:
     - include_role:
         name: linux-system-roles.storage
+        public: true
 
     - name: test lvm and xfs package deps
       include_tasks: run_blivet.yml


### PR DESCRIPTION
The tests_deps.yml test was using include_vars assuming the symlink
roles/linux-system-roles.storage was present.  This is deprecated.
The test was doing this in order to get the defaults and vars from
the role.  The better way to do this is to use `include_role` with
the `public: true` parameter so that the role will expose its private
variables to the play.
