### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,7 @@
+blivet_package_list:
+  - python3-blivet
+  - libblockdev-crypto
+  - libblockdev-dm
+  - libblockdev-lvm
+  - libblockdev-mdraid
+  - libblockdev-swap


### PR DESCRIPTION
From now the `rhel-8-y` status is the latest unreleased RHEL-8 and the `rhel-x` status is pre-released RHEL-9.