### PR TITLE
Capture inherited volume type in return value.

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -794,6 +794,7 @@ def _get_blivet_volume(blivet_obj, volume, bpool=None):
     if volume_type not in _BLIVET_VOLUME_TYPES:
         raise BlivetAnsibleError("Volume '%s' has unknown type '%s'" % (volume['name'], volume_type))
 
+    volume['type'] = volume_type
     return _BLIVET_VOLUME_TYPES[volume_type](blivet_obj, volume, bpool=bpool)
 
 

--- a/tests/tests_missing_volume_type_in_pool.yml
+++ b/tests/tests_missing_volume_type_in_pool.yml
@@ -1,0 +1,76 @@
+---
+- hosts: all
+  become: true
+  vars:
+    storage_safe_mode: false
+    mount_location: '/opt/test1'
+
+  tasks:
+    - include_role:
+        name: linux-system-roles.storage
+
+    - include_tasks: get_unused_disk.yml
+      vars:
+        max_return: 1
+
+    - name: Create a partition device mounted on "{{ mount_location }}"
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: "{{ unused_disks[0] }}"
+            type: partition
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                fs_type: ext4
+                mount_point: "{{ mount_location }}"
+
+    - name: Ensure the inherited type is reflected in blivet module output
+      assert:
+        that: blivet_output.pools[0].volumes[0].type == "partition"
+        msg: "Incorrect type assigned to un-typed volume in partition pool"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the partition created above
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: "{{ unused_disks[0] }}"
+            type: partition
+            disks: "{{ unused_disks }}"
+            state: absent
+            volumes:
+              - name: "{{ unused_disks[0] }}1"
+                mount_point: "{{ mount_location }}"
+                state: absent
+
+    - name: Ensure the inherited type is reflected in blivet module output
+      assert:
+        that: blivet_output.pools[0].volumes[0].type == "partition"
+        msg: "Incorrect type assigned to un-typed volume in partition pool"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Repeat the previous invocation to verify idempotence
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: "{{ unused_disks[0] }}"
+            type: partition
+            disks: "{{ unused_disks }}"
+            state: absent
+            volumes:
+              - name: "{{ unused_disks[0] }}1"
+                mount_point: "{{ mount_location }}"
+                state: absent
+
+    - name: Ensure the inherited type is reflected in blivet module output
+      assert:
+        that: blivet_output.pools[0].volumes[0].type == "partition"
+        msg: "Incorrect type assigned to un-typed volume in partition pool"
+
+    - include_tasks: verify-role-results.yml


### PR DESCRIPTION
The operations performed were already correct, but the `blivet` module's return value showed the wrong type for the volume.