### PR TITLE
Allow a tolerance of up to 1% when verifying volume size in tests.

### DIFF
--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -48,6 +48,6 @@
     var: storage_test_expected_size
 
 - assert:
-    that: storage_test_actual_size.bytes == storage_test_expected_size|int
+    that: (storage_test_expected_size|int - storage_test_actual_size.bytes)|abs / storage_test_expected_size|int < 0.01
     msg: "Volume {{ storage_test_volume.name }} has unexpected size ({{ storage_test_expected_size|int }} / {{ storage_test_actual_size.bytes }})"
   when: _storage_test_volume_present and storage_test_volume.type == "lvm"


### PR DESCRIPTION
This should prevent spurious test failures due to metadata or partition alignment.