### PR TITLE
use volume1_size; check for expected error

### DIFF
--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -103,7 +103,7 @@
                 disks: "{{ unused_disks[0] }}"
                 volumes:
                   - name: test1
-                    size: "{{ volume_size }}"
+                    size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
 
         - name: unreachable task
@@ -111,19 +111,13 @@
             msg: UNREACH
 
       rescue:
-        - name: Check that we failed in the role
+        - name: Verify the output
           assert:
             that:
-              - ansible_failed_result.msg != 'UNREACH'
-            msg: "Role has not failed when it should have"
-
-    # the following does not work properly
-    # - name: Verify the output
-    #   assert:
-    #     that: "{{ blivet_output.failed and
-    #               blivet_output.msg|regex_search('disk.+list') and
-    #               not blivet_output.changed }}"
-    #     msg: "Unexpected behavior w/ disks not in list form"
+              - blivet_output.failed
+              - blivet_output.msg | regex_search('disk.+list')
+              - not blivet_output.changed
+            msg: "Unexpected behavior w/ disks not in list form"
 
     - name: Test for correct handling of missing disk specification.
       block:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1990793
The test was using `volume_size`, which is undefined, instead
of `volume1_size`.  Furthermore, the error was being masked by
the `rescue` block because the rescue was not checking for the
correct error message.  The fix is to use `volume1_size` AND check
for the correct error message.

I'll note that there are several tests that do not look for the
correct error message, and we may run into this problem with other
tests.