### PR TITLE
skip test if kvdo and dm-vdo are not found

### DIFF
--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -25,7 +25,9 @@
         blivet_pkg_version: "{{ ansible_facts.packages[blivet_pkg_name[0]][0]['version'] + '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
 
     - name: Check if kvdo is loadable
-      command: modprobe --dry-run kvdo
+      shell: |
+        set -euo pipefail
+        modprobe --dry-run kvdo && modprobe --dry-run dm-vdo
       ignore_errors: true
       changed_when: false
       register: __storage_kvdo_loadable


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1991062

Am getting this error when testing vdo:
```
Failed to commit changes to disk: Process reported exit code 3: modprobe: FATAL: Module dm-vdo not found in directory /lib/modules/5.14.0-0.rc4.35.el9.x86_64
  /usr/sbin/modprobe failed: 1
  vdo: Required device-mapper target(s) not detected in your kernel.
  Run `lvcreate --help' for more information.
```
So I'll just skip vdo testing unless both kvdo and dm-vdo are found.