### PR TITLE
Nested module params checking

### DIFF
--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -18,6 +18,7 @@ plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:module-invalid-version-added
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:module-invalid-version-added
+plugins/module_utils/storage_lsr/argument_validator.py import-2.6!skip
 plugins/module_utils/storage_lsr/size.py pep8!skip
 tests/storage/scripts/generate_tests.py metaclass-boilerplate!skip
 tests/storage/scripts/generate_tests.py future-import-boilerplate!skip

--- a/.sanity-ansible-ignore-2.11.txt
+++ b/.sanity-ansible-ignore-2.11.txt
@@ -18,6 +18,7 @@ plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:module-invalid-version-added
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:module-invalid-version-added
+plugins/module_utils/storage_lsr/argument_validator.py import-2.6!skip
 plugins/module_utils/storage_lsr/size.py pep8!skip
 plugins/module_utils/storage_lsr/size.py pylint!skip
 tests/storage/scripts/generate_tests.py metaclass-boilerplate!skip

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -32,6 +32,7 @@ plugins/modules/resolve_blockdev.py validate-modules:module-invalid-version-adde
 plugins/module_utils/storage_lsr/__init__.py import-2.6!skip
 plugins/module_utils/storage_lsr/__init__.py import-2.7!skip
 plugins/module_utils/storage_lsr/__init__.py import-3.5!skip
+plugins/module_utils/storage_lsr/argument_validator.py import-2.6!skip
 plugins/module_utils/storage_lsr/size.py import-2.6!skip
 plugins/module_utils/storage_lsr/size.py import-2.7!skip
 plugins/module_utils/storage_lsr/size.py import-3.5!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -11,6 +11,7 @@ plugins/modules/bsize.py validate-modules:missing-gplv3-license
 plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
+plugins/module_utils/storage_lsr/argument_validator.py import-2.6!skip
 plugins/module_utils/storage_lsr/size.py pep8!skip
 tests/storage/scripts/generate_tests.py metaclass-boilerplate!skip
 tests/storage/scripts/generate_tests.py future-import-boilerplate!skip

--- a/module_utils/storage_lsr/argument_validator.py
+++ b/module_utils/storage_lsr/argument_validator.py
@@ -1,0 +1,168 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+__metaclass__ = type
+
+# pylint: disable=undefined-variable
+STRING_TYPE = str if sys.version_info.major == 3 else basestring  # noqa:F821
+
+
+class ArgValidator(object):
+
+    @classmethod
+    def _validate_list(cls, value):
+        if isinstance(value, list):
+            return value
+
+        if isinstance(value, STRING_TYPE):
+            return value.split(",")
+
+        if isinstance(value, int) or isinstance(value, float):
+            return [value]
+
+        raise TypeError("'%s' has to be a list" % value)
+
+    @classmethod
+    def _validate_str(cls, value):
+        return str(value)
+
+    @classmethod
+    def _validate_bool(cls, value):
+        BOOLEANS_TRUE = ['y', 'yes', 'on', '1', 'true', 't', 1, 1.0, True]
+        BOOLEANS_FALSE = ['n', 'no', 'off', '0', 'false', 'f', 0, 0.0, False]
+
+        if value in BOOLEANS_TRUE:
+            return True
+        if value in BOOLEANS_FALSE:
+            return False
+        if value is None:
+            return None
+        raise TypeError("'%s' has to be convertable to a bool" % value)
+
+    @classmethod
+    def _validate_int(cls, value):
+        try:
+            return int(value)
+        except ValueError:
+            raise TypeError("'%s' has to be an integer" % value)
+
+    @classmethod
+    def _validate_float(cls, value):
+        try:
+            return float(value)
+        except ValueError:
+            raise TypeError("'%s' has to be a float" % value)
+
+    @classmethod
+    def validate_item(cls, spec, param, key):
+        # validate and return normalized value of a given parameter based on spec
+        # raises TypeError, ValueError on failure
+
+        if key not in param or param[key] is None:
+            # if the parameter is not specified, use default if defined
+            return spec[key].get('default', None)
+
+        choices = spec[key].get('choices')
+        if choices is not None and param[key] not in choices:
+            raise ValueError("'%s' has to be one of: %s" % (param[key], ', '.join(choices)))
+
+        validate = cls.VALIDATION_TYPE_DISPATCHER[spec[key].get('type', 'str')]
+
+        normalized_value = validate(param[key])
+
+        return normalized_value
+
+    @classmethod
+    def validate_list(cls, spec_type, values):
+        # raises TypeError, ValueError on failure
+
+        normalized_list = list()
+        for value in values:
+            validate = cls.VALIDATION_TYPE_DISPATCHER[spec_type]
+            normalized_value = validate(value)
+            normalized_list.append(normalized_value)
+
+        return normalized_list
+
+
+ArgValidator.VALIDATION_TYPE_DISPATCHER = dict(list=ArgValidator._validate_list,
+                                               str=ArgValidator._validate_str,
+                                               bool=ArgValidator._validate_bool,
+                                               int=ArgValidator._validate_int,
+                                               float=ArgValidator._validate_float)
+
+
+def validate_parameters(argument_spec, parameters, error_log=None, updated_params=None):
+    # recursively validate and normalize all parameters based on argument specifications
+
+    if error_log is None:
+        error_log = list()
+    if updated_params is None:
+        updated_params = dict()
+
+    for spec, value in argument_spec.items():
+
+        if spec not in parameters:
+            # normalize unused parameters
+            try:
+                # value is not defined, try to use default
+                updated_params[spec] = value['default']
+                # cannot use value.get('default', *); * could be the default
+            except KeyError:
+                # value is not defined and has no default value
+                if value['type'] == 'list':
+                    updated_params[spec] = list()
+                elif value['type'] == 'dict':
+                    updated_params[spec] = dict()
+                else:
+                    updated_params[spec] = None
+
+        elif value.get('type') == 'dict':
+            if 'options' not in value:
+                # generic dict, no way to check its contents
+                updated_params[spec] = parameters[spec]
+            else:
+                # nested dict
+                errors, up_params = validate_parameters(value['options'], parameters[spec])
+                if errors:
+                    # recursion will build prefixes of the error messages
+                    errors = [spec + '->' + x for x in errors]
+                    error_log.extend(errors)
+                updated_params[spec] = up_params
+
+        elif value.get('type') == 'list':
+            if 'options' in value and value.get('elements', '') == 'dict':
+                # nested list of dicts
+                updated_params[spec] = list()
+                for item in parameters[spec]:
+                    errors, up_params = validate_parameters(value['options'], item)
+                    if errors:
+                        # recursion will build prefixes of the error messages
+                        errors = [spec + '->' + x for x in errors]
+                        error_log.extend(errors)
+                    updated_params[spec].append(up_params)
+            elif 'elements' not in value:
+                # generic list, no way to check its contents
+                updated_params[spec] = parameters[spec]
+            else:
+                # list of items of defined type
+                try:
+                    normalized_list = ArgValidator.validate_list(value['elements'], parameters[spec])
+                except (TypeError, ValueError) as e:
+                    normalized_list = "ERROR"
+                    error_log.append(spec + ': ' + str(e))
+
+                updated_params[spec] = normalized_list
+
+        else:
+            # ordinary type
+            try:
+                normalized_value = ArgValidator.validate_item(argument_spec, parameters, spec)
+            except (TypeError, ValueError) as e:
+                normalized_value = "ERROR"
+                error_log.append(spec + ': ' + str(e))
+
+            updated_params[spec] = normalized_value
+
+    return (error_log, updated_params)

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -27,7 +27,8 @@
 - name: Verify PV count
   assert:
     that: "{{ _storage_test_pool_pvs_lvm|length == _storage_test_expected_pv_count|int }}"
-    msg: "Unexpected PV count for pool {{ storage_test_pool.name }}"
+    msg: "Unexpected PV count for pool {{ storage_test_pool.name }}
+          (has: {{ _storage_test_pool_pvs_lvm|length }} expected: {{ _storage_test_expected_pv_count|int }})"
   when: storage_test_pool.type == 'lvm'
 
 - set_fact:
@@ -45,7 +46,8 @@
 - name: Check the type of each PV
   assert:
     that: "{{ storage_test_blkinfo.info[pv]['type'] == _storage_test_expected_pv_type }}"
-    msg: "Incorrect type for PV {{ pv }} in pool {{ storage_test_pool.name }}"
+    msg: "Incorrect type for PV {{ pv }} (has: '{{ storage_test_blkinfo.info[pv]['type'] }}'
+          expected: '{{ _storage_test_expected_pv_type }})' in pool '{{ storage_test_pool.name }}'"
   loop: "{{ _storage_test_pool_pvs }}"
   loop_control:
     loop_var: pv

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -20,14 +20,14 @@
       vars:
         max_return: 1
 
-    - name: Create a disk device mounted on "{{ mount_location }}"
+    - name: Create a disk device mounted on "{{ mount_location }}"; specify disks as non-list
       include_role:
         name: linux-system-roles.storage
       vars:
         storage_volumes:
           - name: test1
             type: disk
-            disks: "{{ unused_disks }}"
+            disks: "{{ unused_disks[0] }}"
             fs_type: ext4
             mount_point: "{{ mount_location }}"
 

--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -3,6 +3,7 @@
   become: true
   vars:
     storage_safe_mode: false
+    storage_use_partitions: true
     mount_location: '/opt/test1'
     volume_group_size: '10g'
     volume_size: '12g'

--- a/tests/tests_deps.yml
+++ b/tests/tests_deps.yml
@@ -22,7 +22,7 @@
                 type: lvm
                 fs_type: xfs
                 state: present
-                mountpoint: '/foo'
+                mount_point: '/foo'
                 encryption: false
 
     - name: Assert unexpected required package list is empty

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -99,33 +99,6 @@
     #               not blivet_output.changed }}"
     #     msg: "Unexpected behavior w/ too-large volume size"
 
-    - name: Test for correct handling of non-list disk specification.
-      block:
-        - name: Try to create LVM pool with disks specified as non-list.
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks[0] }}"
-                volumes:
-                  - name: test1
-                    size: "{{ volume1_size }}"
-                    mount_point: "{{ mount_location1 }}"
-
-        - name: unreachable task
-          fail:
-            msg: UNREACH
-
-      rescue:
-        - name: Verify the output
-          assert:
-            that:
-              - blivet_output.failed
-              - blivet_output.msg | regex_search('disk.+list')
-              - not blivet_output.changed
-            msg: "Unexpected behavior w/ disks not in list form"
-
     - name: Test for correct handling of missing disk specification.
       block:
         - name: Try to create LVM pool with no disks specified.


### PR DESCRIPTION
Older versions of ansible do not validate nested modules parameters for
types etc. Ansible 2.11 and newer implement this functionality. This
commit adds type definitions for nested variables.