### PR TITLE
revert fix for testing bz1991062

### DIFF
--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -27,7 +27,7 @@
     - name: Check if kvdo is loadable
       shell: |
         set -euo pipefail
-        modprobe --dry-run kvdo && modprobe --dry-run dm-vdo
+        modprobe --dry-run kvdo
       ignore_errors: true
       changed_when: false
       register: __storage_kvdo_loadable


### PR DESCRIPTION
It seems that vdo is working on rhel 8.5
vdo is working on rhel 9 with the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1989253

So I am reverting this workaround.