### PR TITLE
workaround for udev issue on some platforms

### DIFF
--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -23,6 +23,10 @@
         min_size: "{{ volume_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a LVM logical volume with default fs_type
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -24,6 +24,10 @@
         min_size: "{{ volume_size }}"
         max_return: 2
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create an LVM partition with the default file system type
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_change_mount.yml
+++ b/tests/tests_change_mount.yml
@@ -22,6 +22,10 @@
         min_size: "{{ volume_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a LVM logical volume mounted at "{{ mount_location_before }}"
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -20,6 +20,10 @@
       vars:
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a disk device mounted on "{{ mount_location }}"
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -26,6 +26,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create one lv which size is equal to vg size
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -25,6 +25,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create two LVM logical volumes under volume group 'foo'
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -20,6 +20,10 @@
       vars:
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a partition device mounted on "{{ mount_location }}"
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -26,6 +26,10 @@
       vars:
         max_return: 2
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a RAID0 device
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -21,6 +21,10 @@
       vars:
         max_return: 2
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a RAID0 device mounted on "{{ mount_location }}"
       include_role:
         name: linux-system-roles.storage
@@ -34,6 +38,10 @@
             mount_point: "{{ mount_location }}"
 
     - include_tasks: verify-role-results.yml
+
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
 
     - name: Repeat the previous invocation to verify idempotence
       include_role:

--- a/tests/tests_deps.yml
+++ b/tests/tests_deps.yml
@@ -7,6 +7,10 @@
         name: linux-system-roles.storage
         public: true
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: test lvm and xfs package deps
       include_tasks: run_blivet.yml
       vars:

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -57,6 +57,11 @@
 
     - name: Test for correct handling of duplicate volume names
       block:
+
+        - name: Workaround for udev issue on some platforms
+          command: udevadm trigger --subsystem-match=block
+          changed_when: false
+
         - name: Try to create two volumes w/ the same name
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_existing_lvm_pool.yml
+++ b/tests/tests_existing_lvm_pool.yml
@@ -23,6 +23,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create one LVM logical volume under one volume group
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_filesystem_one_disk.yml
+++ b/tests/tests_filesystem_one_disk.yml
@@ -19,6 +19,10 @@
       vars:
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Initialize a disk device with the default fs type
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -20,6 +20,10 @@
     ##
     - name: Test for correct handling of new encrypted volume w/ no key
       block:
+        - name: Workaround for udev issue on some platforms
+          command: udevadm trigger --subsystem-match=block
+          changed_when: false
+
         - name: Create an encrypted disk volume w/ default fs
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -29,6 +29,10 @@
 
     - name: Test for correct handling of new encrypted pool w/ no key
       block:
+        - name: Workaround for udev issue on some platforms
+          command: udevadm trigger --subsystem-match=block
+          changed_when: false
+
         - name: Create an encrypted lvm pool
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_lvm_auto_size_cap.yml
+++ b/tests/tests_lvm_auto_size_cap.yml
@@ -43,6 +43,10 @@
 
     - name: Test handling of too-large LVM volume size
       block:
+        - name: Workaround for udev issue on some platforms
+          command: udevadm trigger --subsystem-match=block
+          changed_when: false
+
         - name: Try to create a pool containing one volume twice the size of the backing disk
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -101,6 +101,10 @@
 
     - name: Test for correct handling of non-list disk specification.
       block:
+        - name: Workaround for udev issue on some platforms
+          command: udevadm trigger --subsystem-match=block
+          changed_when: false
+
         - name: Try to create LVM pool with disks specified as non-list.
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -24,6 +24,10 @@
         max_return: 2
         disks_needed: 2
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a logical volume spanning two physical volumes that changes its mount location
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_lvm_one_disk_multiple_volumes.yml
+++ b/tests/tests_lvm_one_disk_multiple_volumes.yml
@@ -21,6 +21,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create three LVM logical volumes under one volume group
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_lvm_one_disk_one_volume.yml
+++ b/tests/tests_lvm_one_disk_one_volume.yml
@@ -22,6 +22,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create one LVM logical volume under one volume group
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -22,6 +22,10 @@
 
     - name: Test for correct handling of invalid percentage-based size specification.
       block:
+        - name: Workaround for udev issue on some platforms
+          command: udevadm trigger --subsystem-match=block
+          changed_when: false
+
         - name: Try to create LVM with an invalid size specification.
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -26,6 +26,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Test creating ext4 filesystem with valid parameter "-Fb 4096"
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_missing_volume_type_in_pool.yml
+++ b/tests/tests_missing_volume_type_in_pool.yml
@@ -20,6 +20,10 @@
       vars:
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a partition device mounted on "{{ mount_location }}"
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_null_raid_pool.yml
+++ b/tests/tests_null_raid_pool.yml
@@ -27,6 +27,10 @@
       register: storage_test_mdstat1
       changed_when: false
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: check that raid_level null does not create raid
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -27,6 +27,10 @@
         max_return: 3
         disks_needed: 3
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a RAID1 device
       include_role:
         name: linux-system-roles.storage
@@ -52,6 +56,10 @@
                 mount_point: "{{ mount_location3 }}"
 
     - include_tasks: verify-role-results.yml
+
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
 
     - name: Repeat the previous invocation minus the pool raid options
       include_role:

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -22,6 +22,10 @@
         max_return: 3
         disks_needed: 3
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a RAID0 device mounted on "{{ mount_location }}"
       include_role:
         name: linux-system-roles.storage
@@ -38,6 +42,10 @@
             state: present
 
     - include_tasks: verify-role-results.yml
+
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
 
     - name: Re-run the same invocation without the RAID params
       include_role:

--- a/tests/tests_remove_mount.yml
+++ b/tests/tests_remove_mount.yml
@@ -22,6 +22,10 @@
         min_size: "{{ volume_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a LVM logical volume mounted at "{{ mount_location_before }}"
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -23,6 +23,10 @@
       vars:
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Removing nonexistent pool (with listed volumes)
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -30,6 +30,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     # For ext4 FS
 
     - name: Create one LVM logical volume with "{{ volume_size_before }}" under one volume group

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -22,6 +22,10 @@
         min_size: "{{ volume_size }}"
         max_return: 2
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: Create a disk device with swap
       include_role:
         name: linux-system-roles.storage

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -22,6 +22,10 @@
         min_size: "{{ volume_size }}"
         max_return: 1
 
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+
     - name: set label
       include_role:
         name: linux-system-roles.storage


### PR DESCRIPTION
On some platforms, udev reports that the device is not in use when
it actually is being used.  This cause the idempotency checking part
of the test to fail.  The solution is to use `udevadm trigger` to
force udev to rescan and pick up any pending changes.