### PR TITLE
Added support for LVM RAID volumes

### DIFF
--- a/README-devel.md
+++ b/README-devel.md
@@ -3,7 +3,8 @@
 ### Overview
 The majority of the role's logic is in `library/blivet.py`, which is a module
 that does the heavy lifting of managing the actual storage configuration. The
-next biggest piece is in `tasks/`, followed by `defaults/`.
+next biggest piece is in `tasks/`, followed by `defaults/`. Storage role python
+imports are located at `module_utils/storage_lsr`.
 
 ### Defaults
 This is where we define the structure of the vars available to users to specify

--- a/README.md
+++ b/README.md
@@ -132,21 +132,35 @@ The `mount_point` specifies the directory on which the file system will be mount
 The `mount_options` specifies custom mount options as a string, e.g.: 'ro'.
 
 ##### `raid_level`
-Specifies RAID level when type is `raid`.
-Accepted values are: `linear`, `striped`, `raid0`, `raid1`, `raid4`, `raid5`, `raid6`, `raid10`
+Specifies RAID level. LVM RAID can be created as well.
+"Regular" RAID volume requires type to be `raid`.
+LVM RAID needs that volume has `storage_pools` parent with type `lvm`,
+`raid_disks` need to be specified as well.
+Accepted values are: `linear` (N/A for LVM RAID), `striped`, `raid0`, `raid1`, `raid4`, `raid5`, `raid6`, `raid10`
+__WARNING__: Changing `raid_level` for a volume is a destructive operation, meaning
+             all data on that volume will be lost as part of the process of
+             removing old and adding new RAID. RAID reshaping is currently not
+             supported.
 
-#### `raid_device_count`
+##### `raid_device_count`
 When type is `raid` specifies number of active RAID devices.
 
-#### `raid_spare_count`
+##### `raid_spare_count`
 When type is `raid` specifies number of spare RAID devices.
 
-#### `raid_metadata_version`
+##### `raid_metadata_version`
 When type is `raid` specifies RAID metadata version as a string, e.g.: '1.0'.
 
-#### `raid_chunk_size`
+##### `raid_chunk_size`
 When type is `raid` specifies RAID chunk size as a string, e.g.: '512 KiB'.
 Chunk size has to be multiple of 4 KiB.
+
+##### `raid_disks`
+Specifies which disks should be used for LVM RAID volume.
+`raid_level` needs to be specified and volume has to have `storage_pools` parent with type `lvm`.
+Accepts sublist of `disks` of parent `storage_pools`.
+In case multiple LVM RAID volumes within the same storage pool, the same disk can be used
+in multiple `raid_disks`.
 
 ##### `encryption`
 This specifies whether the volume will be encrypted using LUKS.

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -51,8 +51,11 @@
     loop_var: pv
   when: storage_test_pool.type == 'lvm'
 
-- name: Check raid
+- name: Check MD RAID
   include_tasks: verify-pool-md.yml
+
+- name: Check LVM RAID
+  include_tasks: verify-pool-members-lvmraid.yml
 
 - name: Check member encryption
   include_tasks: verify-pool-members-encryption.yml

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -6,7 +6,9 @@
 - name: Get expected mount device based on device type
   set_fact:
     storage_test_device_path: "{{ storage_test_volume._kernel_device
-      if _storage_test_volume_present and not storage_test_volume.encryption and storage_test_volume.raid_level
+      if _storage_test_volume_present and not storage_test_volume.encryption and
+      storage_test_volume.raid_level and
+      (storage_test_pool is not defined or storage_test_pool is none)
       else storage_test_volume._device }}"
 
 - name: Set some facts

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -96,3 +96,57 @@
                 mount_point: "{{ mount_location3 }}"
 
     - include_tasks: verify-role-results.yml
+
+    - name: Create a RAID1 lvm raid device
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: present
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+                mount_point: "{{ mount_location1 }}"
+                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                raid_level: raid1
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Repeat the previous invocation to verify idempotence
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: present
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+                mount_point: "{{ mount_location1 }}"
+                raid_level: raid1
+                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove the device created above
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: absent
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+                mount_point: "{{ mount_location1 }}"
+                raid_level: raid1
+                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+    - include_tasks: verify-role-results.yml

--- a/tests/verify-pool-member-lvmraid.yml
+++ b/tests/verify-pool-member-lvmraid.yml
@@ -16,4 +16,3 @@
     - storage_test_lvmraid_volume.raid_level is not none
     - storage_test_pool.state != "absent"
     - storage_test_lvmraid_volume.state != "absent"
-

--- a/tests/verify-pool-member-lvmraid.yml
+++ b/tests/verify-pool-member-lvmraid.yml
@@ -1,0 +1,19 @@
+- name: check LVM RAID
+  block:
+    - name: Get information about LVM RAID
+      command: "lvs --noheading -o lv_name --select 'lv_name={{ storage_test_lvmraid_volume.name }}&&lv_layout={{ storage_test_lvmraid_volume.raid_level }}' {{ storage_test_pool.name }}"
+      register: storage_test_lvmraid_status
+      changed_when: false
+
+    - name: Check that volume is LVM RAID
+      assert:
+        that: storage_test_lvmraid_status.stdout | trim == storage_test_lvmraid_volume.name
+
+    - set_fact:
+        storage_test_lvmraid_status: null
+
+  when:
+    - storage_test_lvmraid_volume.raid_level is not none
+    - storage_test_pool.state != "absent"
+    - storage_test_lvmraid_volume.state != "absent"
+

--- a/tests/verify-pool-members-lvmraid.yml
+++ b/tests/verify-pool-members-lvmraid.yml
@@ -1,0 +1,6 @@
+- name: Validate pool member LVM RAID settings
+  include_tasks: verify-pool-member-lvmraid.yml
+  loop: "{{ storage_test_pool.volumes }}"
+  loop_control:
+    loop_var: storage_test_lvmraid_volume
+  when: storage_test_pool.type == 'lvm'


### PR DESCRIPTION
- raid_level can be used on pool volume
- raid_disks can specify disks to be used
- test added
- refactored BlivetLVMVolume._create
- some changes to README-devel (more to come)