### PR TITLE
add tags to allow skipping lvm tests

### DIFF
--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -6,6 +6,8 @@
     mount_location: '/opt/test1'
     volume_size: '5g'
     fs_after: "{{ (ansible_distribution == 'RedHat' and ansible_distribution_major_version == '6') | ternary('ext4', 'xfs') }}"
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -7,6 +7,8 @@
     mount_location: '/opt/test1'
     volume_size: '5g'
     fs_type_after: "{{ 'ext3' if (ansible_distribution == 'RedHat' and ansible_distribution_major_version == '6') else 'ext4' }}"
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_change_mount.yml
+++ b/tests/tests_change_mount.yml
@@ -5,6 +5,8 @@
     mount_location_before: '/opt/test1'
     mount_location_after: '/opt/test2'
     volume_size: '3g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -9,6 +9,8 @@
     unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
     disk_size: '{{ unused_disk_subfact.sectors|int *
                    unused_disk_subfact.sectorsize|int }}'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -8,6 +8,8 @@
     volume_group_size: '10g'
     volume1_size: '5g'
     volume2_size: '4g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -7,6 +7,8 @@
     volume_group_size: '10g'
     volume_size: '12g'
     pool_size: '9g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -10,6 +10,8 @@
     volume1_size: '2g'
     volume3_size: '3g'
     volume2_size: '3g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -4,6 +4,8 @@
   vars:
     mount_location: '/opt/test1'
     testfile: "{{ mount_location }}/quux"
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_existing_lvm_pool.yml
+++ b/tests/tests_existing_lvm_pool.yml
@@ -6,6 +6,8 @@
     volume_group_size: '5g'
     volume_size: '4g'
     pool_name: foo
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_fatals_raid_pool.yml
+++ b/tests/tests_fatals_raid_pool.yml
@@ -10,6 +10,8 @@
     volume1_size: '2g'
     volume3_size: '3g'
     volume2_size: '3g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -5,7 +5,8 @@
     mount_location: '/opt/test1'
     testfile: "{{ mount_location }}/quux"
     volume_size: '5g'
-
+  tags:
+    - tests::lvm
   tasks:
     - include_role:
         name: linux-system-roles.storage

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -7,6 +7,8 @@
     testfile: "{{ mount_location }}/quux"
     testfile_location_2: "{{ mount_location_2 }}/quux"
     volume_size: '5g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_lvm_auto_size_cap.yml
+++ b/tests/tests_lvm_auto_size_cap.yml
@@ -1,7 +1,8 @@
 ---
 - hosts: all
   become: true
-
+  tags:
+    - tests::lvm
   tasks:
     - include_role:
         name: linux-system-roles.storage

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -11,6 +11,8 @@
       - '/non/existent/disk'
     invalid_size: 'xyz GiB'
     unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -6,6 +6,8 @@
     mount_location2: '/opt/test2'
     volume_group_size: '5g'
     volume_size: '4g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_lvm_one_disk_multiple_volumes.yml
+++ b/tests/tests_lvm_one_disk_multiple_volumes.yml
@@ -4,6 +4,8 @@
   vars:
     volume_group_size: '10g'
     volume_size: '3g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_lvm_one_disk_one_volume.yml
+++ b/tests/tests_lvm_one_disk_one_volume.yml
@@ -5,6 +5,8 @@
     mount_location: '/opt/test1'
     volume_group_size: '5g'
     volume_size: '4g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -10,6 +10,8 @@
     size2: "40%"
     size3: "25%"
     size4: "50%"
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -9,6 +9,8 @@
     unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
     too_large_size: '{{ (unused_disk_subfact.sectors|int * 1.2) *
                         unused_disk_subfact.sectorsize|int }}'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_null_raid_pool.yml
+++ b/tests/tests_null_raid_pool.yml
@@ -6,6 +6,8 @@
     storage_use_partitions: true
     mount_location1: '/opt/test1'
     volume1_size: '2g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -10,6 +10,8 @@
     volume1_size: '2g'
     volume3_size: '3g'
     volume2_size: '3g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_remove_mount.yml
+++ b/tests/tests_remove_mount.yml
@@ -5,6 +5,8 @@
     mount_location_before: '/opt/test1'
     mount_location_after: ''
     volume_size: '3g'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -5,6 +5,8 @@
     storage_safe_mode: false
     storage_use_partitions: true
     mount_location1: '/opt/test1'
+  tags:
+    - tests::lvm
 
   # This tests the issue when removing nonexistent pool (with listed volumes)
   # caused crash

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -13,6 +13,8 @@
                         unused_disk_subfact.sectorsize|int }}'
     disk_size: '{{ unused_disk_subfact.sectors|int *
                    unused_disk_subfact.sectorsize|int }}'
+  tags:
+    - tests::lvm
 
   tasks:
     - include_role:


### PR DESCRIPTION
lvm is currently broken on el9.  We need to skip these tests until
lvm is fixed.  See https://bugzilla.redhat.com/show_bug.cgi?id=1967212