### PR TITLE
add support for storage_udevadm_trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Default value is equal to the size of the volume.
 #### `storage_safe_mode`
 When true (the default), an error will occur instead of automatically removing existing devices and/or formatting.
 
+#### `storage_udevadm_trigger`
+When true (the default is false), the role will use udevadm trigger
+to cause udev changes to take effect immediately.  This may help on some
+platforms with "buggy" udev.
 
 Example Playbook
 ----------------

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -85,6 +85,14 @@
         diskvolume_mkfs_option_map: "{{ __storage_blivet_diskvolume_mkfs_option_map|d(omit) }}"
         # yamllint enable rule:line-length
       register: blivet_output
+
+    - name: Workaround for udev issue on some platforms
+      command: udevadm trigger --subsystem-match=block
+      changed_when: false
+      when:
+        - storage_udevadm_trigger | d(false)
+        - blivet_output is changed
+
   rescue:
     - name: failed message
       fail:


### PR DESCRIPTION
On some platforms, udev is not updated immediately after blivet
completes its disk operations.  The user can set
`storage_udevadm_trigger: true` in order to cause udev to ensure
those changes take effect immediately.