### PR TITLE
Add workaround for incosistent udev DB state after RAID creation

### DIFF
--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -5,6 +5,7 @@
     storage_safe_mode: false
     storage_use_partitions: true
     mount_location: '/opt/test1'
+    storage_udevadm_trigger: true
 
   tasks:
     - include_role:


### PR DESCRIPTION
For newly created array in test_raid_volume_options, the spare
drive sometimes doesn't have the linux_raid_member FS type in the
udev database which means Blivet doesn't recognize it as a part
of the array. Forcing udev to rescan the devices after creating
the array should fix this issue.