### PR TITLE
WIP - wait for system to reboot after crash

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -85,9 +85,8 @@
         diskvolume_mkfs_option_map: "{{ __storage_blivet_diskvolume_mkfs_option_map|d(omit) }}"
         # yamllint enable rule:line-length
       register: blivet_output
-
-    - name: Wait for remote system in case blivet crashes it
-      wait_for_connection:
+      async: 300
+      poll: 1
 
     - name: Workaround for udev issue on some platforms
       command: udevadm trigger --subsystem-match=block

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -86,6 +86,9 @@
         # yamllint enable rule:line-length
       register: blivet_output
 
+    - name: Wait for remote system in case blivet crashes it
+      wait_for_connection:
+
     - name: Workaround for udev issue on some platforms
       command: udevadm trigger --subsystem-match=block
       changed_when: false

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -85,7 +85,7 @@
         diskvolume_mkfs_option_map: "{{ __storage_blivet_diskvolume_mkfs_option_map|d(omit) }}"
         # yamllint enable rule:line-length
       register: blivet_output
-      async: 120
+      async: 180
       poll: 5
 
     - name: Workaround for udev issue on some platforms

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -96,6 +96,15 @@
         - blivet_output is changed
 
   rescue:
+    - name: look for kernel crash
+      shell: |
+        for dir in /var/crash/*; do
+          ls -alrtF "$dir"
+          if [ -f "$dir/vmcore-dmesg.txt" ]; then
+            tail -100 "$dir/vmcore-dmesg.txt"
+          fi
+        done
+
     - name: failed message
       fail:
         msg: "{{ ansible_failed_result }}"

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -85,8 +85,8 @@
         diskvolume_mkfs_option_map: "{{ __storage_blivet_diskvolume_mkfs_option_map|d(omit) }}"
         # yamllint enable rule:line-length
       register: blivet_output
-      async: 300
-      poll: 1
+      async: 120
+      poll: 5
 
     - name: Workaround for udev issue on some platforms
       command: udevadm trigger --subsystem-match=block


### PR DESCRIPTION
Something about the tests_create_raid_pool_then_remove.yml is causing
systems to crash.  This only happens with the legacy CI systems.  I
have been unable to reproduce with local qemu tests.  Not sure if other
tests have this problem.  It appears to be some interaction between mdadm
and certain kernel features.
```
[   76.421268] md127: detected capacity change from 21453864960 to 0
[   76.422340] md: md127 stopped.
[   76.473075]  nvme1n1: p1
[   76.513004]  nvme1n1:
[   76.583514]  vdc: vdc1
[   76.615838]  vdc:
[   91.201130]  vdc:
[   91.270296]  vdc:
[   91.361068]  vdc: vdc1
[   91.451005]  nvme1n1:
[   91.536964]  nvme1n1:
[   91.638012]  nvme1n1: p1
[   91.861057] async_tx: api initialized (async)
[   91.863649] xor: automatically using best checksumming function:
[   91.873811]    avx       : 26024.000 MB/sec
[   91.898805] raid6: sse2x1   gen() 11601 MB/s
[   91.915807] raid6: sse2x2   gen() 14347 MB/s
[   91.932805] raid6: sse2x4   gen() 16000 MB/s
[   91.949806] raid6: avx2x1   gen() 20156 MB/s
[   91.966807] raid6: avx2x2   gen() 26113 MB/s
[   91.983805] raid6: avx2x4   gen() 27972 MB/s
[   91.984830] invalid opcode: 0000 [#1] SMP 
[   91.985586] Modules linked in: raid6_pq(+) async_xor xor async_tx raid0 dm_mod ex
t4 mbcache jbd2 nls_utf8 isofs nfit libnvdimm iosf_mbi crc32_pclmul ghash_clmulni_in
tel ppdev cirrus ttm drm_kms_helper aesni_intel lrw syscopyarea gf128mul sysfillrect
 glue_helper sysimgblt ablk_helper fb_sys_fops cryptd drm joydev pcspkr parport_pc s
g parport virtio_rng drm_panel_orientation_quirks i2c_piix4 ip_tables xfs libcrc32c 
sr_mod sd_mod cdrom crc_t10dif crct10dif_generic ata_generic pata_acpi virtio_net vi
rtio_scsi net_failover virtio_blk failover ata_piix crct10dif_pclmul crct10dif_commo
n crc32c_intel nvme serio_raw libata nvme_core virtio_pci virtio_ring virtio floppy 
sunrpc
...
[   91.999880] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 0.5.1 01/
01/2011
[   92.001427] task: ffff91f6b49fc1c0 ti: ffff91f6b8d9c000 task.ti: ffff91f6b8d9c000
[   92.002885] RIP: 0010:[<ffffffffc088b31a>]  [<ffffffffc088b31a>] raid6_avx5121_ge
n_syndrome+0x4a/0x190 [raid6_pq]
[   92.004835] RSP: 0018:ffff91f6b8d9fc20  EFLAGS: 00010246
[   92.005959] RAX: ffff91f6b5d6e600 RBX: ffff91f6b8d9fc70 RCX: ffff91f6b49fc1c0
[   92.007380] RDX: 00000000ffffffff RSI: 0000000000000080 RDI: ffff91f6b5d6e600
[   92.008809] RBP: ffff91f6b8d9fc50 R08: ffffffffc088b2d0 R09: 0000000000000002
[   92.010285] R10: 0000000000000298 R11: 0000000000000000 R12: 0000000000001000
[   92.011727] R13: ffff91f6ba094000 R14: ffff91f6ba095000 R15: 0000000000000012
[   92.013162] FS:  00007f3c2f8aa740(0000) GS:ffff91f6bfc80000(0000) knlGS:000000000
0000000
[   92.014756] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[   92.015983] CR2: 00000000019c2000 CR3: 000000007a2bc000 CR4: 00000000003607e0
[   92.017432] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[   92.018884] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[   92.020366] Call Trace:
[   92.021112]  [<ffffffffc06aa11e>] init_module+0x11e/0x1000 [raid6_pq]
[   92.022540]  [<ffffffffc06aa000>] ? 0xffffffffc06a9fff
[   92.023740]  [<ffffffff8c80210a>] do_one_initcall+0xba/0x240
[   92.025001]  [<ffffffff8c91ee4a>] load_module+0x271a/0x2bb0
[   92.026217]  [<ffffffff8cbb3340>] ? ddebug_proc_write+0x100/0x100
[   92.027514]  [<ffffffff8c91f3cf>] SyS_init_module+0xef/0x140
[   92.028741]  [<ffffffff8cf92ed2>] system_call_fastpath+0x25/0x2a
[   92.030028] Code: 00 00 00 00 53 48 89 d3 48 83 ec 08 48 89 75 d0 4c 8b 2c c2 4c 
8b 74 32 08 e8 f3 cb fa cb 84 c0 0f 84 1b 01 00 00 e8 f6 cc fa cb <62> f1 fd 48 6f 0
5 dc 38 01 00 62 f1 f5 48 ef c9 4d 85 e4 0f 84 
[   92.035213] RIP  [<ffffffffc088b31a>] raid6_avx5121_gen_syndrome+0x4a/0x190 [raid
6_pq]
[   92.036863]  RSP <ffff91f6b8d9fc20>
```