### PR TITLE
Disable ansible parameter checking

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1580,10 +1580,11 @@ def run_module():
         packages=list(),
     )
 
-    module = AnsibleModule(argument_spec=module_args,
+    dummy_args = dict(parameters=dict(type='list', default=list()))
+    module = AnsibleModule(argument_spec=dummy_args,
                            supports_check_mode=True)
 
-    errors, updated_params = validate_parameters(module_args, module.params)
+    errors, updated_params = validate_parameters(module_args, module.params['parameters'][0])
     if errors:
         module.fail_json(msg="Parameter check failed: %s" % errors)
 

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -21,13 +21,14 @@
 
 - name: get required packages
   blivet:
-    pools: "{{ storage_pools|default([]) }}"
-    volumes: "{{ storage_volumes|default([]) }}"
-    use_partitions: "{{ storage_use_partitions }}"
-    disklabel_type: "{{ storage_disklabel_type }}"
-    pool_defaults: "{{ storage_pool_defaults }}"
-    volume_defaults: "{{ storage_volume_defaults }}"
-    packages_only: true
+    parameters:
+      - pools: "{{ storage_pools|default([]) }}"
+        volumes: "{{ storage_volumes|default([]) }}"
+        use_partitions: "{{ storage_use_partitions }}"
+        disklabel_type: "{{ storage_disklabel_type }}"
+        pool_defaults: "{{ storage_pool_defaults }}"
+        volume_defaults: "{{ storage_volume_defaults }}"
+        packages_only: true
   register: package_info
   when: storage_skip_checks is not defined or
         not "packages_installed" in storage_skip_checks
@@ -74,16 +75,17 @@
 
     - name: manage the pools and volumes to match the specified state
       blivet:
-        pools: "{{ storage_pools|default([]) }}"
-        volumes: "{{ storage_volumes|default([]) }}"
-        use_partitions: "{{ storage_use_partitions }}"
-        disklabel_type: "{{ storage_disklabel_type }}"
-        pool_defaults: "{{ storage_pool_defaults }}"
-        volume_defaults: "{{ storage_volume_defaults }}"
-        safe_mode: "{{ storage_safe_mode }}"
-        # yamllint disable-line rule:line-length
-        diskvolume_mkfs_option_map: "{{ __storage_blivet_diskvolume_mkfs_option_map|d(omit) }}"
-        # yamllint enable rule:line-length
+        parameters:
+          - pools: "{{ storage_pools|default([]) }}"
+            volumes: "{{ storage_volumes|default([]) }}"
+            use_partitions: "{{ storage_use_partitions }}"
+            disklabel_type: "{{ storage_disklabel_type }}"
+            pool_defaults: "{{ storage_pool_defaults }}"
+            volume_defaults: "{{ storage_volume_defaults }}"
+            safe_mode: "{{ storage_safe_mode }}"
+            # yamllint disable-line rule:line-length
+            diskvolume_mkfs_option_map: "{{ __storage_blivet_diskvolume_mkfs_option_map|d(omit) }}"
+            # yamllint enable rule:line-length
       register: blivet_output
 
     - name: Workaround for udev issue on some platforms

--- a/tests/run_blivet.yml
+++ b/tests/run_blivet.yml
@@ -1,9 +1,10 @@
 ---
 - name: test lvm and xfs package deps
   blivet:
-    packages_only: "{{ packages_only }}"
-    pools: "{{ storage_pools|default([]) }}"
-    volumes: "{{ storage_volumes|default([]) }}"
-    pool_defaults: "{{ storage_pool_defaults }}"
-    volume_defaults: "{{ storage_volume_defaults }}"
+    parameters:
+      - packages_only: "{{ packages_only }}"
+        pools: "{{ storage_pools|default([]) }}"
+        volumes: "{{ storage_volumes|default([]) }}"
+        pool_defaults: "{{ storage_pool_defaults }}"
+        volume_defaults: "{{ storage_volume_defaults }}"
   register: blivet_output


### PR DESCRIPTION
Because older ansible versions do not check nested parameter values,
storage role implements its own argument validation in addition
to ansible parameter checking.

Change in this commit bridges over ansible parameter checking which effectively
disables it. This opens us the way to implement custom types (i.e. Size) and checks
needed for further development of the role (e.g. thin pool support).

Overall storage role behavior remains unchanged.