### PR TITLE
allow role to work with gather_facts: false

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__storage_required_facts) == __storage_required_facts
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,5 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
-
+  gather_facts: false
   roles:
     - linux-system-roles.storage

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,6 @@
+# ansible_facts required by the role
+__storage_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Allow the role to work if the playbook has set `gather_facts: false`.
The `gather_subset: min` includes all of the facts used by this
role.  Other roles may need to gather more facts.
The role gathers the facts where they are needed.  Other roles may
need to gather facts in a different place.
