### PR TITLE
[citest skip] bump tox-lsr version to 2.11.0; remove py37; add py310

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10']
+        pyver: ['2.7', '3.6', '3.8', '3.9', '3.10', '3.10']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2


### PR DESCRIPTION
tox-lsr version 2.11.0 has support for collection-requirements.yml,
runqemu improvements, and support for python 3.10

python 3.7 is not used on any supported platform, so remove it