### PR TITLE
Thin pool support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,10 @@ storage_volume_defaults:
   deduplication: null
   vdo_pool_size: null
 
+  thin: null
+  thin_pool_name: null
+  thin_pool_size: null
+
   cached: false
   cache_size: 0
   cache_mode: null

--- a/module_utils/storage_lsr/argument_validator.py
+++ b/module_utils/storage_lsr/argument_validator.py
@@ -7,6 +7,26 @@ __metaclass__ = type
 # pylint: disable=undefined-variable
 STRING_TYPE = str if sys.version_info.major == 3 else basestring  # noqa:F821
 
+BOOLEANS_TRUE = ['y', 'yes', 'on', '1', 'true', 't', 1, 1.0, True]
+BOOLEANS_FALSE = ['n', 'no', 'off', '0', 'false', 'f', 0, 0.0, False]
+
+# Combinations of parameters (and their values) that will raise exception
+# use [] if value does not matter
+
+# example: {'options': {'pools.encryption:[True]', pools.volumes.deduplication:[True]}, 'err_msg:' 'deduplication cannot be used with encryption'}
+UNSUPPORTED_COMBOS = [{'options': {'pools.volumes.encryption': BOOLEANS_TRUE,
+                                   'pools.volumes.deduplication': BOOLEANS_TRUE},
+                       'err_msg': "Deduplication is not supported on encrypted volumes"},
+                      {'options': {'pools.volumes.encryption': BOOLEANS_TRUE,
+                                   'pools.volumes.compression': BOOLEANS_TRUE},
+                       'err_msg': "Compression is not supported on encrypted volumes"},
+                      {'options': {'pools.volumes.thin': BOOLEANS_TRUE,
+                                   'pools.volumes.compression': BOOLEANS_TRUE},
+                       'err_msg': "Dedupliation is not supported on thin pool volumes"},
+                      {'options': {'pools.volumes.thin': BOOLEANS_TRUE,
+                                   'pools.volumes.deduplication': BOOLEANS_TRUE},
+                       'err_msg': "Compression is not supported on thin pool volumes"}]
+
 
 class ArgValidator(object):
 
@@ -29,8 +49,6 @@ class ArgValidator(object):
 
     @classmethod
     def _validate_bool(cls, value):
-        BOOLEANS_TRUE = ['y', 'yes', 'on', '1', 'true', 't', 1, 1.0, True]
-        BOOLEANS_FALSE = ['n', 'no', 'off', '0', 'false', 'f', 0, 0.0, False]
 
         if value in BOOLEANS_TRUE:
             return True
@@ -93,7 +111,7 @@ ArgValidator.VALIDATION_TYPE_DISPATCHER = dict(list=ArgValidator._validate_list,
                                                float=ArgValidator._validate_float)
 
 
-def validate_parameters(argument_spec, parameters, error_log=None, updated_params=None):
+def _validate_parameters(argument_spec, parameters, error_log=None, updated_params=None):
     # recursively validate and normalize all parameters based on argument specifications
 
     if error_log is None:
@@ -124,7 +142,7 @@ def validate_parameters(argument_spec, parameters, error_log=None, updated_param
                 updated_params[spec] = parameters[spec]
             else:
                 # nested dict
-                errors, up_params = validate_parameters(value['options'], parameters[spec])
+                errors, up_params = _validate_parameters(value['options'], parameters[spec])
                 if errors:
                     # recursion will build prefixes of the error messages
                     errors = [spec + '->' + x for x in errors]
@@ -136,7 +154,7 @@ def validate_parameters(argument_spec, parameters, error_log=None, updated_param
                 # nested list of dicts
                 updated_params[spec] = list()
                 for item in parameters[spec]:
-                    errors, up_params = validate_parameters(value['options'], item)
+                    errors, up_params = _validate_parameters(value['options'], item)
                     if errors:
                         # recursion will build prefixes of the error messages
                         errors = [spec + '->' + x for x in errors]
@@ -166,3 +184,172 @@ def validate_parameters(argument_spec, parameters, error_log=None, updated_param
             updated_params[spec] = normalized_value
 
     return (error_log, updated_params)
+
+
+def generate_combinations(input_list):
+    # Create list of all valid combinations of parameters
+    # (Note: 'valid' means 'worth exploring')
+
+    # Fill in the stack with the first item to expand
+    stack = [[{'path': input_list[0]['path'],
+               'indices': x,
+               'backtrack_indices': input_list[0]['backtrack_indices']}]
+             for x in input_list[0]['indices']]
+
+    result = []
+
+    while stack:
+        sequence = stack.pop()
+        for item in input_list[len(sequence)]['indices']:
+            new_sequence = sequence + [{'path': input_list[len(sequence)]['path'],
+                                        'indices': item,
+                                        'backtrack_indices': input_list[len(sequence)]['backtrack_indices']}]
+            if len(new_sequence) < len(input_list):
+                stack.append(new_sequence)
+            else:
+                # sequence is complete, now to make sure the combination is valid
+
+                # 'valid' means that all the same path roots have the same indices
+                indices_pairs = {}
+                for rule in new_sequence:
+                    encountered_index = indices_pairs.get(rule['path'][0], -1)
+                    if encountered_index == -1:
+                        # path not yet encountered
+                        indices_pairs[rule['path'][0]] = rule['indices'][0]
+                    elif encountered_index != rule['indices'][0]:
+                        # invalid combination
+                        break
+                else:
+                    # for loop ended without break - combination is valid
+                    result.append(new_sequence)
+
+    return result
+
+
+def locate_parameter(params, path, param_value):
+    # path: complete path of searched parameter e.g. "['pools', 'volumes', 'deduplication']"
+    # param_value: list of searched values or [] if value doesn't matter
+    # returns list of "hash" of matching items or [] when not found
+
+    # Stack. Each item consists of
+    # - "value"   - (part of) nested dictionary
+    # - "level"   - depth of nest (e.g. for "pool[1].volume[0].size": level=1 ~ "pool[1].volume[0]")
+    # - "indices" - list of indices (e.g. for "pool[1].volume[0].size": indices == [1, 0, None])
+    stack = [{'value': params, 'level': 0, 'indices': []}]
+    result = {'path': path, 'indices': []}
+
+    while stack:
+
+        stack_item = stack.pop()
+
+        if stack_item['level'] < len(path):
+
+            path_step = path[stack_item['level']]
+            # Expand stack item
+            item = stack_item['value'].get(path_step)
+
+            if isinstance(item, list):
+                # Push each list item back into the stack
+                for idx in range(len(item)):
+                    stack.append({'value': item[idx],
+                                  'level': stack_item['level'] + 1,
+                                  'indices': stack_item['indices'] + [idx]})
+            else:
+                # Push expanded item back into the stack
+                stack.append({'value': item,
+                              'level': stack_item['level'] + 1,
+                              'indices': stack_item['indices'] + [None]})
+        else:
+            # The end of given path
+            if param_value == list() or stack_item['value'] in param_value:
+                result['indices'].append(stack_item['indices'])
+
+    if result['indices'] == []:
+        return None
+
+    return result
+
+
+def format_result(combo):
+    rules_list = list()
+    for rule in combo:
+        path_list = rule['path'][0].split('.')
+        indices = rule['backtrack_indices']
+
+        rule_str = ""
+        for i in range(len(path_list)):
+            rule_str += path_list[i]
+            if i < len(indices) and indices[i] is not None:
+                rule_str += '[' + str(indices[i]) + ']'
+            rule_str += '.'
+        rules_list.append(rule_str[:-1])
+    return rules_list
+
+
+def check_param_combos(params):
+    all_combos = list()
+
+    for combo in UNSUPPORTED_COMBOS:
+
+        found_combos = list()
+        recorded_matches = list()
+
+        for key, value in combo['options'].items():
+            found = locate_parameter(params, key.split('.'), value)
+            if found is None:
+                # Locate found nothing => the whole combo is clean, no need to continue
+                break
+            else:
+                recorded_matches.append(found)
+        else:
+            # No break happened in loop => need to check result combinations
+
+            for match in recorded_matches:
+                match['backtrack_indices'] = list()
+
+            stack = [recorded_matches]
+
+            while stack:
+                match = stack.pop()
+                combinations = generate_combinations(match)
+
+                # It is now possible to dive by shifting the root one level
+                for combination in combinations:
+                    shifted_combo = list()
+                    combo_found = True
+                    for rule in combination:
+                        if len(rule['path']) > 1:
+                            path = rule['path'][1:]
+                            path[0] = rule['path'][0] + '.' + path[0]
+                            indices = [rule['indices'][1:]]
+                            backtrack_indices = rule['backtrack_indices'] + [rule['indices'][0]]
+                            combo_found = False
+                        else:
+                            path = rule['path']
+                            indices = [rule['indices']]
+                            backtrack_indices = rule['backtrack_indices']
+
+                        shifted_combo.append({'path': path,
+                                              'indices': indices,
+                                              'backtrack_indices': backtrack_indices})
+
+                    if combo_found:
+                        # Forbidden combination of parameters confirmed
+                        found_combos.append(format_result(combination))
+                    else:
+                        stack.append(shifted_combo)
+        if found_combos != list():
+            all_combos.append({'matches': found_combos, 'msg': combo['err_msg']})
+
+    return all_combos
+
+
+def validate_parameters(argument_spec, parameters, error_log=None, updated_params=None):
+
+    errors, up_params = _validate_parameters(argument_spec, parameters)
+
+    found_combos = check_param_combos(up_params)
+    for combo in found_combos:
+        errors.append('%s: %s' % (combo['msg'], combo['matches']))
+
+    return errors, up_params

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -59,6 +59,9 @@
 - name: Check LVM RAID
   include_tasks: verify-pool-members-lvmraid.yml
 
+- name: Check Thin Pools
+  include_tasks: verify-pool-members-thin.yml
+
 - name: Check member encryption
   include_tasks: verify-pool-members-encryption.yml
 

--- a/tests/tests_create_thinp_then_remove.yml
+++ b/tests/tests_create_thinp_then_remove.yml
@@ -1,0 +1,125 @@
+---
+- hosts: all
+  become: true
+  vars:
+    storage_safe_mode: false
+    storage_use_partitions: true
+    mount_location1: '/opt/test1'
+    mount_location2: '/opt/test2'
+    volume1_size: '3g'
+    volume2_size: '4g'
+    fs_after: "{{ (ansible_distribution == 'RedHat' and ansible_distribution_major_version == '6') | ternary('ext4', 'xfs') }}"
+
+  tasks:
+    - include_role:
+        name: linux-system-roles.storage
+
+    - include_tasks: get_unused_disk.yml
+      vars:
+        max_return: 3
+
+    - name: Create a thinpool device
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: present
+            volumes:
+              - name: lv1
+                thin_pool_name: tpool1
+                thin_pool_size: '10g'
+                size: "{{ volume1_size }}"
+                thin: true
+                mount_point: "{{ mount_location1 }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Repeat previous invocation to verify idempotence
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            volumes:
+              - name: lv1
+                thin_pool_name: tpool1
+                thin_pool_size: '10g'
+                size: "{{ volume1_size }}"
+                thin: true
+                mount_point: "{{ mount_location1 }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Change thinlv fs type
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            volumes:
+              - name: lv1
+                thin_pool_name: tpool1
+                thin: true
+                fs_type: "{{ fs_after }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Create new LV under existing thinpool
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            volumes:
+              - name: lv2
+                thin_pool_name: tpool1
+                size: "{{ volume2_size }}"
+                thin: true
+                mount_point: "{{ mount_location2 }}"
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Remove existing LV under existing thinpool
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            volumes:
+              - name: lv2
+                thin_pool_name: tpool1
+                thin: true
+                mount_point: "{{ mount_location2 }}"
+                state: absent
+
+    - include_tasks: verify-role-results.yml
+
+    - name: Cleanup
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: absent
+            volumes:
+              - name: lv1
+                thin_pool_name: tpool1
+                thin_pool_size: '10g'
+                size: "{{ volume1_size }}"
+                thin: true
+                mount_point: "{{ mount_location1 }}"
+
+    - include_tasks: verify-role-results.yml

--- a/tests/verify-pool-member-thin.yml
+++ b/tests/verify-pool-member-thin.yml
@@ -1,0 +1,23 @@
+- name: check thinpool
+  block:
+    - name: Get information about thinpool
+      command: "lvs --noheading -o pool_lv --select 'lv_name={{ storage_test_thin_volume.name }}&&segtype=thin' {{ storage_test_pool.name }}"
+      register: storage_test_thin_status
+      changed_when: false
+
+    - name: Check that volume is in correct thinpool (when thinp name is provided)
+      assert:
+        that: storage_test_thin_status.stdout | trim == storage_test_thin_volume.thin_pool_name
+      when: storage_test_thin_volume.thin_pool_name is not none
+
+    - name: Check that volume is in thinpool (when thinp name is not provided)
+      assert:
+        that: storage_test_thin_status.stdout | trim != ""
+
+    - set_fact:
+        storage_test_lvmraid_status: null
+
+  when:
+    - storage_test_thin_volume.thin
+    - storage_test_pool.state != "absent"
+    - storage_test_thin_volume.state != "absent"

--- a/tests/verify-pool-members-thin.yml
+++ b/tests/verify-pool-members-thin.yml
@@ -1,0 +1,6 @@
+- name: Validate pool member thinpool settings
+  include_tasks: verify-pool-member-thin.yml
+  loop: "{{ storage_test_pool.volumes }}"
+  loop_control:
+    loop_var: storage_test_thin_volume
+  when: storage_test_pool.type == 'lvm'


### PR DESCRIPTION
Storage role support for thin provisioning.
Volumes under LVM pool now can use three new options:
 - 'thin' - type bool
          - setting to True puts the volume into a thin pool
 - 'thin_pool_name' - type str
          - specifies the name of the thin pool for this volume
          - selects thin pool with the same name if it exists
          - tries to create new thin pool if it does not
          - if omitted and no existing thin pool is present, the name is generated automatically
          - if omitted and exactly one thin pool is present, the volume is put into existing thin pool
          - if omitted and more than one thin pool is present, exception is raised
 - 'thin_pool_size' - type Size
          - specifeis size of the thin pool