### PR TITLE
add support for mount_options

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -105,6 +105,7 @@ volumes:
     elements: dict
 '''
 
+import copy
 import logging
 import os
 import traceback
@@ -1500,6 +1501,39 @@ def activate_swaps(b, pools, volumes):
 
 def run_module():
     # available arguments/parameters that a user can pass
+    common_volume_opts = dict(encryption=dict(type='bool'),
+                              encryption_cipher=dict(type='str'),
+                              encryption_key=dict(type='str'),
+                              encryption_key_size=dict(type='int'),
+                              encryption_luks_version=dict(type='str'),
+                              encryption_password=dict(type='str'),
+                              fs_create_options=dict(type='str'),
+                              fs_label=dict(type='str', default=''),
+                              fs_type=dict(type='str'),
+                              mount_options=dict(type='str'),
+                              mount_point=dict(type='str'),
+                              name=dict(type='str'),
+                              raid_level=dict(type='str'),
+                              size=dict(type='str'),
+                              state=dict(type='str', default='present', choices=['present', 'absent']),
+                              type=dict(type='str'))
+    volume_opts = copy.deepcopy(common_volume_opts)
+    volume_opts.update(
+        dict(disks=dict(type='list'),
+             raid_device_count=dict(type='int'),
+             raid_spare_count=dict(type='int'),
+             raid_metadata_version=dict(type='str')))
+    pool_volume_opts = copy.deepcopy(common_volume_opts)
+    pool_volume_opts.update(
+        dict(cached=dict(type='bool'),
+             cache_devices=dict(type='list', elements='str', default=list()),
+             cache_mode=dict(type='str'),
+             cache_size=dict(type='str'),
+             compression=dict(type='bool'),
+             deduplication=dict(type='bool'),
+             raid_disks=dict(type='list', elements='str', default=list()),
+             vdo_pool_size=dict(type='str')))
+
     module_args = dict(
         pools=dict(type='list', elements='dict',
                    options=dict(disks=dict(type='list', elements='str', default=list()),
@@ -1517,49 +1551,9 @@ def run_module():
                                 state=dict(type='str', default='present', choices=['present', 'absent']),
                                 type=dict(type='str'),
                                 volumes=dict(type='list', elements='dict', default=list(),
-                                             options=dict(cached=dict(type='bool'),
-                                                          cache_devices=dict(type='list', elements='str', default=list()),
-                                                          cache_mode=dict(type='str'),
-                                                          cache_size=dict(type='str'),
-                                                          compression=dict(type='bool'),
-                                                          deduplication=dict(type='bool'),
-                                                          encryption=dict(type='bool'),
-                                                          encryption_cipher=dict(type='str'),
-                                                          encryption_key=dict(type='str'),
-                                                          encryption_key_size=dict(type='int'),
-                                                          encryption_luks_version=dict(type='str'),
-                                                          encryption_password=dict(type='str'),
-                                                          fs_create_options=dict(type='str'),
-                                                          fs_label=dict(type='str', default=''),
-                                                          fs_type=dict(type='str'),
-                                                          mount_point=dict(type='str'),
-                                                          name=dict(type='str'),
-                                                          raid_disks=dict(type='list', elements='str', default=list()),
-                                                          raid_level=dict(type='str'),
-                                                          size=dict(type='str'),
-                                                          state=dict(type='str', default='present', choices=['present', 'absent']),
-                                                          type=dict(type='str'),
-                                                          vdo_pool_size=dict(type='str'))))),
+                                             options=pool_volume_opts))),
         volumes=dict(type='list', elements='dict',
-                     options=dict(disks=dict(type='list'),
-                                  encryption=dict(type='bool'),
-                                  encryption_cipher=dict(type='str'),
-                                  encryption_key=dict(type='str'),
-                                  encryption_key_size=dict(type='int'),
-                                  encryption_luks_version=dict(type='str'),
-                                  encryption_password=dict(type='str'),
-                                  fs_create_options=dict(type='str'),
-                                  fs_label=dict(type='str', default=''),
-                                  fs_type=dict(type='str'),
-                                  mount_point=dict(type='str'),
-                                  name=dict(type='str'),
-                                  raid_level=dict(type='str'),
-                                  raid_device_count=dict(type='int'),
-                                  raid_spare_count=dict(type='int'),
-                                  raid_metadata_version=dict(type='str'),
-                                  size=dict(type='str'),
-                                  state=dict(type='str', default='present', choices=['present', 'absent']),
-                                  type=dict(type='str'))),
+                     options=volume_opts),
         packages_only=dict(type='bool', required=False, default=False),
         disklabel_type=dict(type='str', required=False, default=None),
         safe_mode=dict(type='bool', required=False, default=True),

--- a/tests/test-verify-volume-fstab.yml
+++ b/tests/test-verify-volume-fstab.yml
@@ -11,6 +11,12 @@
     storage_test_fstab_expected_mount_point_matches: "{{ 1
       if (_storage_test_volume_present and storage_test_volume.mount_point and storage_test_volume.mount_point.startswith('/'))
       else 0 }}"
+    storage_test_fstab_mount_options_matches: "{{ storage_test_fstab.stdout_lines |
+      map('regex_search', ' ' + storage_test_volume.mount_point + ' .* ' + storage_test_volume.mount_options + ' +') |
+      select('string')|list if (storage_test_volume.mount_options|d('none',true) != 'none') else [] }}"
+    storage_test_fstab_expected_mount_options_matches: "{{ 1
+      if (_storage_test_volume_present and storage_test_volume.mount_options)
+      else 0 }}"
 
 # device id
 - name: Verify that the device identifier appears in /etc/fstab
@@ -26,7 +32,13 @@
     msg: "Expected number ({{ storage_test_fstab_expected_mount_point_matches }}) of
       entries with volume '{{ storage_test_volume.name }}' mount point not found in /etc/fstab."
 
-# todo: options
+# mount options
+- name: Verify mount_options
+  assert:
+    that: storage_test_fstab_mount_options_matches|length == storage_test_fstab_expected_mount_options_matches|int
+    msg: "Expected number ({{ storage_test_fstab_expected_mount_options_matches }}) of
+      entries with volume '{{ storage_test_volume.name }}' mount options not found in /etc/fstab."
+  when: "'mount_options' in storage_test_volume"
 
 - name: Clean up variables
   set_fact:
@@ -34,3 +46,5 @@
     storage_test_fstab_mount_point_matches: null
     storage_test_fstab_expected_id_matches: null
     storage_test_fstab_expected_mount_point_matches: null
+    storage_test_fstab_mount_options_matches: null
+    storage_test_fstab_expected_mount_options_matches: null

--- a/tests/test-verify-volume-fstab.yml
+++ b/tests/test-verify-volume-fstab.yml
@@ -13,7 +13,10 @@
       else 0 }}"
     storage_test_fstab_mount_options_matches: "{{ storage_test_fstab.stdout_lines |
       map('regex_search', ' ' + storage_test_volume.mount_point + ' .* ' + storage_test_volume.mount_options + ' +') |
-      select('string')|list if (storage_test_volume.mount_options|d('none',true) != 'none') else [] }}"
+      select('string')|list if (
+        storage_test_volume.mount_options|d('none',true) != 'none'
+        and storage_test_volume.mount_point|d('none',true) != 'none'
+      ) else [] }}"
     storage_test_fstab_expected_mount_options_matches: "{{ 1
       if (_storage_test_volume_present and storage_test_volume.mount_options)
       else 0 }}"
@@ -38,7 +41,10 @@
     that: storage_test_fstab_mount_options_matches|length == storage_test_fstab_expected_mount_options_matches|int
     msg: "Expected number ({{ storage_test_fstab_expected_mount_options_matches }}) of
       entries with volume '{{ storage_test_volume.name }}' mount options not found in /etc/fstab."
-  when: "'mount_options' in storage_test_volume"
+  when:
+    - __storage_verify_mount_options | d(false)
+    - "'mount_options' in storage_test_volume"
+    - "'mount_point' in storage_test_volume"
 
 - name: Clean up variables
   set_fact:

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -189,6 +189,7 @@
             fs_type: 'ext4'
             fs_create_options: '-F'
             mount_point: "{{ mount_location }}"
+            mount_options: rw,noatime,defaults
 
     - include_tasks: verify-role-results.yml
 

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -192,6 +192,8 @@
             mount_options: rw,noatime,defaults
 
     - include_tasks: verify-role-results.yml
+      vars:
+        __storage_verify_mount_options: true
 
     - name: Remove the disk volume created above
       include_role:


### PR DESCRIPTION
When support for argument validation was added, that support did not
include the `mount_options` parameter.  This fix adds back that
parameter.  In addition, the volume module arguments are refactored
so that the common volume parameters such as `mount_options` can be
specified in one place.

This adds a test for the `mount_options` parameter, and adds
verification for that parameter.
