### PR TITLE
make striped an alias for raid0

### DIFF
--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -40,7 +40,8 @@
   when: storage_test_pool.type == 'lvm' and not storage_test_pool.encryption
 
 - set_fact:
-    _storage_test_expected_pv_type: "{{ storage_test_pool.raid_level }}"
+    _storage_test_expected_pv_type: "{{ (storage_test_pool.raid_level == 'striped') |
+      ternary('raid0', storage_test_pool.raid_level) }}"
   when: storage_test_pool.type == 'lvm' and storage_test_pool.raid_level
 
 - name: Check the type of each PV

--- a/tests/test-verify-volume-device.yml
+++ b/tests/test-verify-volume-device.yml
@@ -27,7 +27,8 @@
 
 - name: (2/2) Process volume type (get RAID value)
   set_fact:
-    st_volume_type: "{{ storage_test_volume.raid_level }}"
+    st_volume_type: "{{ (storage_test_volume.raid_level == 'striped') |
+      ternary('raid0', storage_test_volume.raid_level) }}"
   when: storage_test_volume.type == "raid"
 
 - name: Verify the volume's device type

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -36,7 +36,7 @@
           - name: vg1
             disks: "{{ unused_disks }}"
             type: lvm
-            raid_level: "raid0"
+            raid_level: "striped"
             state: present
             volumes:
               - name: lv1

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -29,7 +29,7 @@
         storage_volumes:
           - name: test1
             type: raid
-            raid_level: "raid0"
+            raid_level: "striped"
             disks: "{{ unused_disks }}"
             mount_point: "{{ mount_location }}"
 

--- a/tests/verify-pool-member-lvmraid.yml
+++ b/tests/verify-pool-member-lvmraid.yml
@@ -1,9 +1,12 @@
 - name: check LVM RAID
   block:
     - name: Get information about LVM RAID
-      command: "lvs --noheading -o lv_name --select 'lv_name={{ storage_test_lvmraid_volume.name }}&&lv_layout={{ storage_test_lvmraid_volume.raid_level }}' {{ storage_test_pool.name }}"
+      command: "lvs --noheading -o lv_name --select 'lv_name={{ storage_test_lvmraid_volume.name }}&&lv_layout={{ __raid_level }}' {{ storage_test_pool.name }}"
       register: storage_test_lvmraid_status
       changed_when: false
+      vars:
+        __raid_level: "{{ (storage_test_lvmraid_volume.raid_level == 'striped') |
+          ternary('raid0', storage_test_lvmraid_volume.raid_level) }}"
 
     - name: Check that volume is LVM RAID
       assert:


### PR DESCRIPTION
blivet does not support a raid_level of `striped`, but it is the same
thing as `raid0`, so make `striped` an alias of `raid0`.
