### PR TITLE
Add support for attaching LVM cache to existing LVs

### DIFF
--- a/tests/tests_create_lvm_cache_then_remove.yml
+++ b/tests/tests_create_lvm_cache_then_remove.yml
@@ -21,6 +21,30 @@
           - packages_installed
           - service_facts
 
+    - name: Gather package facts
+      package_facts:
+        # gather information about packages
+
+    - name: Set blivet package name
+      set_fact:
+        blivet_pkg_name: "{{ ansible_facts.packages | select('search','blivet') | select('search', 'python') | list }}"
+
+    - name: Set blivet package version
+      set_fact:
+        blivet_pkg_version: "{{ ansible_facts.packages[blivet_pkg_name[0]][0]['version'] + '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
+
+    - name: Set distribution version
+      set_fact:
+        is_rhel9: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'Enterprise Linux' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version == '9' }}"
+        is_rhel8: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'Enterprise Linux' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version =='8' }}"
+        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
+
     - include_tasks: get_unused_disk.yml
       vars:
         min_size: "{{ volume_group_size }}"
@@ -56,6 +80,25 @@
                 cached: false
 
     - include_tasks: verify-role-results.yml
+
+    - block:
+        - name: Attach the cache to the 'test' LV created above
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test
+                    size: "{{ volume_size }}"
+                    cached: true
+                    cache_size: "{{ cache_size }}"
+                    cache_devices: "{{ [unused_disks[1]] }}"
+        - include_tasks: verify-role-results.yml
+      when: ((is_fedora and blivet_pkg_version is version("3.5.0-1", ">=")) or
+             (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
+             (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">=")))
 
     - name: Clean up
       include_role:


### PR DESCRIPTION
Fixes: #252

Note: The tests will now fail everywhere for now because the blivet with support for cache creation is not yet released. I'll make sure to properly skip the test on systems with old blivet when I know which version(s) supports it on RHEL and Fedora.