### PR TITLE
Skip the entire test_lvm_pool_members playbook with old blivet

### DIFF
--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -44,6 +44,12 @@
                     ansible_facts.distribution_major_version =='8' }}"
         is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
+    # end early when running with old blivet where removing PVs from a VG fails
+    - meta: end_play
+      when: ((is_fedora and blivet_pkg_version is version("3.4.3-1", "<")) or
+             (is_rhel8 and blivet_pkg_version is version("3.4.0-10", "<")) or
+             (is_rhel9 and blivet_pkg_version is version("3.4.0-14", "<")))
+
     - include_tasks: get_unused_disk.yml
       vars:
         min_size: "{{ volume_group_size }}"
@@ -190,67 +196,61 @@
       assert:
         that: storage_test_members_vg_uuid.stdout == storage_test_members_vg_uuid_after.stdout
 
-    - block:
-        # test with an LV, older blivet fails in some cases with an active LV present
-        - name: Create a new volume group with a logical volume
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks[0] }}"
-                encryption: false
-                volumes:
-                  - name: test
-                    size: "{{ volume_size }}"
+    - name: Create a new volume group with a logical volume
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks[0] }}"
+            encryption: false
+            volumes:
+              - name: test
+                size: "{{ volume_size }}"
 
-        - name: Save UUID of the created volume group
-          command: "vgs --noheading -o vg_uuid foo"
-          register: storage_test_members_vg_uuid
+    - name: Save UUID of the created volume group
+      command: "vgs --noheading -o vg_uuid foo"
+      register: storage_test_members_vg_uuid
 
-        - include_tasks: verify-role-results.yml
+    - include_tasks: verify-role-results.yml
 
-        - name: Add a second PV to the VG
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-                volumes:
-                  - name: test
-                    size: "{{ volume_size }}"
+    - name: Add a second PV to the VG
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+            volumes:
+              - name: test
+                size: "{{ volume_size }}"
 
-        - name: Get UUID of the 'foo' volume group
-          command: "vgs --noheading -o vg_uuid foo"
-          register: storage_test_members_vg_uuid_after
+    - name: Get UUID of the 'foo' volume group
+      command: "vgs --noheading -o vg_uuid foo"
+      register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
-          assert:
-            that: storage_test_members_vg_uuid.stdout == storage_test_members_vg_uuid_after.stdout
+    - name: Make sure the VG UUID didn't change (VG wasn't removed)
+      assert:
+        that: storage_test_members_vg_uuid.stdout == storage_test_members_vg_uuid_after.stdout
 
-        - name: Remove the first PV from the VG
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ [unused_disks[1]] }}"
-                volumes:
-                  - name: test
-                    size: "{{ volume_size }}"
+    - name: Remove the first PV from the VG
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ [unused_disks[1]] }}"
+            volumes:
+              - name: test
+                size: "{{ volume_size }}"
 
-        - name: Get UUID of the 'foo' volume group
-          command: "vgs --noheading -o vg_uuid foo"
-          register: storage_test_members_vg_uuid_after
+    - name: Get UUID of the 'foo' volume group
+      command: "vgs --noheading -o vg_uuid foo"
+      register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
-          assert:
-            that: storage_test_members_vg_uuid.stdout == storage_test_members_vg_uuid_after.stdout
-
-      when: ((is_fedora and blivet_pkg_version is version("3.4.3-1", ">=")) or
-             (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
-             (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">=")))
+    - name: Make sure the VG UUID didn't change (VG wasn't removed)
+      assert:
+        that: storage_test_members_vg_uuid.stdout == storage_test_members_vg_uuid_after.stdout
 
     - name: Clean up
       include_role:

--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -34,19 +34,19 @@
 
     - name: Set distribution version
       set_fact:
-        is_rhel9: "{{ (ansible_facts.distribution == 'CentOS' or
-                    ansible_facts.distribution == 'Enterprise Linux' or
-                    ansible_facts.distribution == 'RedHat') and
-                    ansible_facts.distribution_major_version == '9' }}"
-        is_rhel8: "{{ (ansible_facts.distribution == 'CentOS' or
-                    ansible_facts.distribution == 'Enterprise Linux' or
-                    ansible_facts.distribution == 'RedHat') and
-                    ansible_facts.distribution_major_version =='8' }}"
-        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
+        is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] == '9' }}"
+        is_rhel8: "{{ ansible_facts['os_family'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] == '8' }}"
+        is_rhel7: "{{ ansible_facts['os_family'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] == '7' }}"
+        is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
 
     # end early when running with old blivet where removing PVs from a VG fails
-    - meta: end_play
+    - name: Skip test if blivet is too old
+      meta: end_play
       when: ((is_fedora and blivet_pkg_version is version("3.4.3-1", "<")) or
+             (is_rhel7 and blivet_pkg_version is version("3.4.0-10", "<")) or
              (is_rhel8 and blivet_pkg_version is version("3.4.0-10", "<")) or
              (is_rhel9 and blivet_pkg_version is version("3.4.0-14", "<")))
 


### PR DESCRIPTION
Multiple bugs in blivet were fixed in order to make the feature
work and without the correct version even the most basic test to
remove a PV from a VG will fail so we should skip the entire test
with old versions of blivet.

----

I originally skipped only the last test case with a logical volume in the VG, but one of the blivet issues also prevents removing a PV from a VG so basically all the tests will fail with older versions of blivet.