### PR TITLE
loop variables are scoped local - no need to reset them

### DIFF
--- a/tests/verify-role-results.yml
+++ b/tests/verify-role-results.yml
@@ -37,10 +37,6 @@
     loop_var: storage_test_pool
   when: _storage_pools_list is defined and _storage_pools_list | length > 0
 
-- name: Clean up variable namespace
-  set_fact:
-    storage_test_pool: null
-
 #
 # Verify standalone volumes.
 #
@@ -59,4 +55,3 @@
     storage_test_fstab: null
     storage_test_crypttab: null
     storage_test_blkinfo: null
-    storage_test_volume: null


### PR DESCRIPTION
If you use
```yaml
  loop_control:
    loop_var: storage_test_pool
```
Then the variable `storage_test_pool` is scoped local to the task
and is undefined after the task.  In addition, referencing the
variable after the loop causes this warning:
```
[WARNING]: The loop variable 'storage_test_pool' is already in use. You should
set the `loop_var` value in the `loop_control` option for the task to something
else to avoid variable collisions and unexpected behavior.
```
