### PR TITLE
Add disks_needed for raid test cases

### DIFF
--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -27,6 +27,7 @@
     - include_tasks: get_unused_disk.yml
       vars:
         max_return: 2
+        disks_needed: 2
 
     - name: Create a RAID0 device
       include_role:

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -20,6 +20,7 @@
     - include_tasks: get_unused_disk.yml
       vars:
         max_return: 2
+        disks_needed: 2
 
     - name: Create a RAID0 device mounted on "{{ mount_location }}"
       include_role:

--- a/tests/tests_fatals_raid_pool.yml
+++ b/tests/tests_fatals_raid_pool.yml
@@ -27,6 +27,7 @@
     - include_tasks: get_unused_disk.yml
       vars:
         max_return: 2
+        disks_needed: 2
 
     - name: Try to create a raid pool with invalid raid_level (expect failure)
       block:

--- a/tests/tests_fatals_raid_volume.yml
+++ b/tests/tests_fatals_raid_volume.yml
@@ -20,6 +20,7 @@
     - include_tasks: get_unused_disk.yml
       vars:
         max_return: 2
+        disks_needed: 2
 
     - name: Try to create a raid pool with invalid raid_level (expect failure)
       block:

--- a/tests/tests_null_raid_pool.yml
+++ b/tests/tests_null_raid_pool.yml
@@ -23,6 +23,7 @@
     - include_tasks: get_unused_disk.yml
       vars:
         max_return: 2
+        disks_needed: 2
 
     - name: get existing raids (before run)
       command: "cat /proc/mdstat"

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -21,6 +21,7 @@
       vars:
         min_size: "{{ volume_size }}"
         max_return: 2
+        disks_needed: 2
 
     - name: Create a disk device with swap
       include_role:


### PR DESCRIPTION
Creating raid will be failed if we don't have enough unused disks, set disks_needed earlier.

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>