### PR TITLE
Use a threshold of 2 percent in volume size check

### DIFF
--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -128,6 +128,6 @@
     var: storage_test_expected_size
 
 - assert:
-    that: (storage_test_expected_size|int - storage_test_actual_size.bytes)|abs / storage_test_expected_size|int < 0.01
+    that: (storage_test_expected_size|int - storage_test_actual_size.bytes)|abs / storage_test_expected_size|int < 0.02
     msg: "Volume {{ storage_test_volume.name }} has unexpected size (expected: {{ storage_test_expected_size|int }} / actual: {{ storage_test_actual_size.bytes }})"
   when: _storage_test_volume_present and storage_test_volume.type == "lvm"


### PR DESCRIPTION
There seems to be an issue calculating the expected size and the
actual size of the volume.  On some systems, the difference is
greater than 1% but less than 2%.  We are working on a better, more
reliable method of calculating the expected and actual sizes.  In
the meantime, make the threshold 2%.
