### PR TITLE
Improve skip tags handling in the tests_lvm_pool_members tests

### DIFF
--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -34,10 +34,11 @@
 
     # end early when running with old blivet where removing PVs from a VG fails
     - name: Run test only if blivet supports this functionality
-      when: ((is_fedora and blivet_pkg_version is version("3.4.3-1", ">=")) or
-             (is_rhel7 and blivet_pkg_version is version("3.4.0-10", ">=")) or
-             (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
-             (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">=")))
+      when: (blivet_pkg_version is defined and
+             ((is_fedora and blivet_pkg_version is version("3.4.3-1", ">=")) or
+              (is_rhel7 and blivet_pkg_version is version("3.4.0-10", ">=")) or
+              (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
+              (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">="))))
       vars:
         is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and
           ansible_facts['distribution_major_version'] == '9' }}"


### PR DESCRIPTION
In case "--skip-tags tests::nvme" is set when running ansible, tests_lvm_pool_members_nvme_generated.yml is not "executed", but the values and the conditions are evaluated. Then, since ansible_facts are not set by the setup module, the variables is_fedora, is_rhel?, and blivet_pkg_version are left undefined, which causes an error in the "when" condition with "'is_fedora' is undefined".

To workaround it, we should check if at least one of the variables is defined before evaluating them.