### PR TITLE
Fix issues found by CodeQL

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -492,6 +492,7 @@ class BlivetVolume(BlivetBase):
             try:
                 self._device.format.update_size_info()
             except AttributeError:
+                # Error handling is done next.
                 pass
 
             if not self._device.resizable:
@@ -1548,20 +1549,21 @@ class FSTab(object):
         if self._entries:
             self.reset()
 
-        for line in open('/etc/fstab').readlines():
-            if line.lstrip().startswith("#"):
-                continue
+        with open('/etc/fstab') as f:
+            for line in f.readlines():
+                if line.lstrip().startswith("#"):
+                    continue
 
-            fields = line.split()
-            if len(fields) < 6:
-                continue
+                fields = line.split()
+                if len(fields) < 6:
+                    continue
 
-            device = self._blivet.devicetree.resolve_device(fields[0])
-            self._entries.append(dict(device_id=fields[0],
-                                      device_path=getattr(device, 'path', None),
-                                      fs_type=fields[2],
-                                      mount_point=fields[1],
-                                      mount_options=fields[3]))
+                device = self._blivet.devicetree.resolve_device(fields[0])
+                self._entries.append(dict(device_id=fields[0],
+                                          device_path=getattr(device, 'path', None),
+                                          fs_type=fields[2],
+                                          mount_point=fields[1],
+                                          mount_options=fields[3]))
 
 
 def get_mount_info(pools, volumes, actions, fstab):

--- a/library/lvm_gensym.py
+++ b/library/lvm_gensym.py
@@ -61,12 +61,15 @@ from ansible.module_utils import facts
 
 def get_os_name():
     """Search the host file and return the name in the ID column"""
-    for line in open('/etc/os-release').readlines():
-        if not line.find('ID='):
-            os_name = line[3:]
-            break
+    os_name = None
+    with open('/etc/os-release') as f:
+        for line in f.readlines():
+            if not line.find('ID='):
+                os_name = line[3:]
+                break
 
-    os_name = os_name.replace('\n', '').replace('"', '')
+    if os_name:
+        os_name = os_name.replace('\n', '').replace('"', '')
     return os_name
 
 

--- a/library/resolve_blockdev.py
+++ b/library/resolve_blockdev.py
@@ -117,6 +117,7 @@ def run_module():
     try:
         result['device'] = resolve_blockdev(module.params['spec'], run_cmd=module.run_command)
     except Exception:
+        # Error handling is done next.
         pass
 
     if not result['device'] or not os.path.exists(result['device']):

--- a/module_utils/storage_lsr/size.py
+++ b/module_utils/storage_lsr/size.py
@@ -53,6 +53,7 @@ class Size(object):
         prefix = raw_units
         no_suffix_flag = True
         valid_suffix = False
+        used_factor = BINARY_FACTOR
 
         # get rid of possible units suffix ('bytes', 'b' or 'B')
         for suffix in SUFFIXES:


### PR DESCRIPTION
library/blivet.py
- 'except' clause does nothing but pass and there is no explanatory comment.
- File is opened but is not closed.

library/resolve_blockdev.py
- 'except' clause does nothing but pass and there is no explanatory comment.

library/lvm_gensym.py
- File is opened but is not closed.
- Local variable 'os_name' may be used before it is initialized.

module_utils/storage_lsr/size.py
- Local variable 'used_factor' may be used before it is initialized.

Signed-off-by: Noriko Hosoi <nhosoi@redhat.com>