### PR TITLE
restrict swap size to less than 128GB on EL7

### DIFF
--- a/library/find_unused_disk.py
+++ b/library/find_unused_disk.py
@@ -30,6 +30,11 @@ options:
         default: '0'
         type: str
 
+    max_size:
+        description: Specifies the maximum disk size to return an unused disk.
+        default: '0'
+        type: str
+
     with_interface:
         description: Specifies which disk interface will be accepted (scsi, virtio, nvme).
         default: null
@@ -157,6 +162,7 @@ def run_module():
     module_args = dict(
         max_return=dict(type='int', required=False, default=10),
         min_size=dict(type='str', required=False, default='0'),
+        max_size=dict(type='str', required=False, default='0'),
         with_interface=dict(type='str', required=False, default=None)
     )
 
@@ -170,6 +176,7 @@ def run_module():
         supports_check_mode=True
     )
 
+    max_size = Size(module.params['max_size'])
     for path, attrs in get_disks(module).items():
         if is_ignored(path):
             continue
@@ -183,6 +190,9 @@ def run_module():
             continue
 
         if Size(attrs["size"]).bytes < Size(module.params['min_size']).bytes:
+            continue
+
+        if max_size.bytes > 0 and Size(attrs["size"]).bytes > max_size.bytes:
             continue
 
         if get_partitions(path):

--- a/tests/get_unused_disk.yml
+++ b/tests/get_unused_disk.yml
@@ -1,9 +1,10 @@
 ---
 - name: Find unused disks in the system
   find_unused_disk:
-    min_size: "{{ min_size | default(omit) }}"
-    max_return: "{{ max_return|default(omit) }}"
-    with_interface: "{{ storage_test_use_interface | default(omit) }}"
+    min_size: "{{ min_size | d(omit) }}"
+    max_size: "{{ max_size | d(omit) }}"
+    max_return: "{{ max_return | d(omit) }}"
+    with_interface: "{{ storage_test_use_interface | d(omit) }}"
   register: unused_disks_return
 
 - name: Set unused_disks if necessary

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -1,19 +1,21 @@
 ---
-- hosts: all
+- name: Test misc features of the storage role
+  hosts: all
   become: true
   vars:
     storage_safe_mode: false
-    mount_location: '/opt/test1'
-    volume_group_size: '5g'
-    volume1_size: '4g'
-    unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
-    too_large_size: '{{ (unused_disk_subfact.sectors|int * 1.2) *
-                        unused_disk_subfact.sectorsize|int }}'
+    mount_location: /opt/test1
+    volume_group_size: "5g"
+    volume1_size: "4g"
+    unused_disk_subfact: "{{ ansible_devices[unused_disks[0]] }}"
+    too_large_size: "{{ (unused_disk_subfact.sectors | int * 1.2) *
+                         unused_disk_subfact.sectorsize | int }}"
   tags:
     - tests::lvm
 
   tasks:
-    - include_role:
+    - name: Include the role to ensure packages are installed
+      include_role:
         name: linux-system-roles.storage
 
     - name: Mark tasks to be skipped
@@ -23,7 +25,8 @@
           - packages_installed
           - service_facts
 
-    - include_tasks: get_unused_disk.yml
+    - name: Get unused disks for test
+      include_tasks: get_unused_disk.yml
       vars:
         min_size: "{{ volume_group_size }}"
         max_return: 1
@@ -38,12 +41,13 @@
             disks: "{{ unused_disks }}"
             volumes:
               - name: test1
-                fs_type: 'ext4'
+                fs_type: ext4
                 size: "{{ volume1_size }}"
-                fs_create_options: '-Fb 4096'
+                fs_create_options: -Fb 4096
                 mount_point: "{{ mount_location }}"
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Remove the volume group created above
       include_role:
@@ -55,7 +59,8 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Test for correct handling of invalid parameter when creating ext4 filesystem
       block:
@@ -69,9 +74,9 @@
                 disks: "{{ unused_disks }}"
                 volumes:
                   - name: test1
-                    fs_type: 'ext4'
+                    fs_type: ext4
                     size: "{{ volume1_size }}"
-                    fs_create_options: '-Fb 512'
+                    fs_create_options: -Fb 512
                     mount_point: "{{ mount_location }}"
 
         - name: Unreachable task
@@ -82,15 +87,20 @@
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_result.msg != 'UNREACH'
-            msg: "Role has not failed when it should have"
+              - ansible_failed_result.msg != "UNREACH"
+            msg: Role has not failed when it should have
 
         - name: Verify the output when creating ext4 filesystem with invalid parameter "-Fb 512"
           assert:
-            that: "blivet_output.failed and
-                   blivet_output.msg|regex_search('Failed to commit changes to disk.*FSError.*format failed: 1.*/dev/mapper/foo-test1') and
-                   not blivet_output.changed"
-            msg: "Unexpected behavior when creating ext4 filesystem whith invalid parameter"
+            that:
+              - blivet_output.failed
+              - blivet_output.msg | regex_search(errmsgpat)
+              - not blivet_output.changed
+            msg: Unexpected behavior when creating ext4 filesystem with invalid parameter
+          vars:
+            errmsgpat: >-
+              Failed to commit changes to disk.*FSError.*format failed:
+              1.*/dev/mapper/foo-test1
 
     - name: Remove the volume group created above
       include_role:
@@ -102,7 +112,7 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Create one LVM logical volume with "{{ volume1_size }}" under one volume group
+    - name: Create one LVM logical volume under one volume group, size {{ volume1_size }}
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -112,11 +122,12 @@
             disks: "{{ unused_disks }}"
             volumes:
               - name: test1
-                fs_type: 'ext4'
+                fs_type: ext4
                 size: "{{ volume1_size }}"
                 mount_point: "{{ mount_location }}"
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Test for correct handling resize large size
       block:
@@ -130,7 +141,7 @@
                 disks: "{{ unused_disks }}"
                 volumes:
                   - name: test1
-                    fs_type: 'ext4'
+                    fs_type: ext4
                     size: "{{ too_large_size }}"
                     mount_point: "{{ mount_location }}"
 
@@ -142,15 +153,18 @@
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_result.msg != 'UNREACH'
-            msg: "Role has not failed when it should have"
+              - ansible_failed_result.msg != "UNREACH"
+            msg: Role has not failed when it should have
 
         - name: Verify the output when resizing with large size
           assert:
-            that: "blivet_output.failed and
-                   blivet_output.msg|regex_search('volume.*test1.*cannot be resized to.*') and
-                   not blivet_output.changed"
-            msg: "Unexpected behavior when resizing with large size"
+            that:
+              - blivet_output.failed
+              - blivet_output.msg | regex_search(errmsgpat)
+              - not blivet_output.changed
+            msg: Unexpected behavior when resizing with large size
+          vars:
+            errmsgpat: volume.*test1.*cannot be resized to.*
 
     - name: Remove the volume group created above
       include_role:
@@ -173,10 +187,11 @@
             volumes:
               - name: test1
                 type: partition
-                fs_type: 'ext4'
+                fs_type: ext4
                 mount_point: "{{ mount_location }}"
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Test setting up disk volume will remove the partition create above
       include_role:
@@ -186,12 +201,13 @@
           - name: foo
             type: disk
             disks: "{{ unused_disks }}"
-            fs_type: 'ext4'
-            fs_create_options: '-F'
+            fs_type: ext4
+            fs_create_options: -F
             mount_point: "{{ mount_location }}"
             mount_options: rw,noatime,defaults
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
       vars:
         __storage_verify_mount_options: true
 
@@ -205,17 +221,32 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Test for correct handling of mounting a non-mountable formatiing type
+    # rhel7 has a limitation of 128g swap size
+    - name: Get unused disks for swap
+      include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "{{ volume_group_size }}"
+        max_return: 1
+        disks_needed: 1
+        max_size: "{{ '127g' if (ansible_facts['os_family'] == 'RedHat'
+          and ansible_facts['distribution_major_version'] is version('8', '<'))
+          else '0' }}"
+
+    - name: Save disk used for swap
+      set_fact:
+        __swap_disk: "{{ unused_disks[0] }}"
+
+    - name: Test for correct handling of mounting a non-mountable formatting type
       block:
-        - name: Try to mount swap filesystem to "{{  mount_location }}"
+        - name: Try to mount swap filesystem to {{ mount_location }}
           include_role:
             name: linux-system-roles.storage
           vars:
             storage_volumes:
               - name: test1
                 type: disk
-                disks: "{{ unused_disks }}"
-                fs_type: 'swap'
+                disks: "{{ [__swap_disk] }}"
+                fs_type: swap
                 mount_point: "{{ mount_location }}"
 
         - name: Unreachable task
@@ -226,12 +257,15 @@
         - name: Check that we failed in the role
           assert:
             that:
-              - ansible_failed_result.msg != 'UNREACH'
+              - ansible_failed_result.msg != "UNREACH"
             msg: "Role has not failed when it should have"
 
-        - name: Verify the output when mount swap filesystem to "{{  mount_location }}"
+        - name: Verify the output when mount swap filesystem to "{{ mount_location }}"
           assert:
-            that: "blivet_output.failed and
-                   blivet_output.msg|regex_search('volume.*test1.*has a mount point but no mountable file system') and
-                   not blivet_output.changed"
-            msg: "Unexpected behavior when mount swap filesystem"
+            that:
+              - blivet_output.failed
+              - blivet_output.msg | regex_search(errmsgpat)
+              - not blivet_output.changed
+            msg: Unexpected behavior when mount swap filesystem
+          vars:
+            errmsgpat: volume.*test1.*has a mount point but no mountable file system

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -1,13 +1,14 @@
 ---
-- hosts: all
-  become: true
+- name: Test management of swap
+  hosts: all
   vars:
     storage_safe_mode: false
-    mount_location: '/opt/test'
+    mount_location: /opt/test
     volume_size: '5g'
 
   tasks:
-    - include_role:
+    - name: Include role to ensure packages are installed
+      include_role:
         name: linux-system-roles.storage
 
     - name: Mark tasks to be skipped
@@ -17,11 +18,20 @@
           - packages_installed
           - service_facts
 
-    - include_tasks: get_unused_disk.yml
+    # rhel7 has a limitation of 128g swap size
+    - name: Get unused disks for swap
+      include_tasks: get_unused_disk.yml
       vars:
         min_size: "{{ volume_size }}"
-        max_return: 2
-        disks_needed: 2
+        max_return: 1
+        disks_needed: 1
+        max_size: "{{ '127g' if (ansible_facts['os_family'] == 'RedHat'
+          and ansible_facts['distribution_major_version'] is version('8', '<'))
+          else '0' }}"
+
+    - name: Save disk used for swap
+      set_fact:
+        __swap_disk: "{{ unused_disks[0] }}"
 
     - name: Create a disk device with swap
       include_role:
@@ -30,10 +40,22 @@
         storage_volumes:
           - name: test1
             type: disk
-            disks: "{{ [unused_disks[0]] }}"
-            fs_type: 'swap'
+            disks: "{{ [__swap_disk] }}"
+            fs_type: swap
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
+
+    - name: Get disk to use for non-swap device
+      include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "{{ volume_size }}"
+        max_return: 1
+        disks_needed: 1
+
+    - name: Save non-swap disk
+      set_fact:
+        __non_swap_disk: "{{ unused_disks[0] }}"
 
     - name: Format second disk as ext3
       include_role:
@@ -44,11 +66,12 @@
             type: disk
             mount_point: none
             fs_type: ext3
-            disks: "{{ [unused_disks[1]] }}"
+            disks: "{{ [__non_swap_disk] }}"
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
-    - name: Change the disk device file system type to ext3
+    - name: Change the disk device file system type from swap to ext3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -57,9 +80,10 @@
             type: disk
             mount_point: "{{ mount_location }}"
             fs_type: ext3
-            disks: "{{ [unused_disks[0]] }}"
+            disks: "{{ [__swap_disk] }}"
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
       include_role:
@@ -70,9 +94,10 @@
             type: disk
             mount_point: "{{ mount_location }}"
             fs_type: ext3
-            disks: "{{ [unused_disks[0]] }}"
+            disks: "{{ [__swap_disk] }}"
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Change it back to swap
       include_role:
@@ -81,10 +106,11 @@
         storage_volumes:
           - name: test1
             type: disk
-            disks: "{{ [unused_disks[0]] }}"
-            fs_type: 'swap'
+            disks: "{{ [__swap_disk] }}"
+            fs_type: swap
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
       include_role:
@@ -93,10 +119,11 @@
         storage_volumes:
           - name: test1
             type: disk
-            disks: "{{ [unused_disks[0]] }}"
-            fs_type: 'swap'
+            disks: "{{ [__swap_disk] }}"
+            fs_type: swap
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml
 
     - name: Clean up
       include_role:
@@ -105,13 +132,14 @@
         storage_volumes:
           - name: test1
             type: disk
-            disks: "{{ [unused_disks[0]] }}"
+            disks: "{{ [__swap_disk] }}"
             mount_point: "{{ mount_location }}"
             state: absent
           - name: test2
             type: disk
-            disks: "{{ [unused_disks[1]] }}"
+            disks: "{{ [__non_swap_disk] }}"
             mount_point: none
             state: absent
 
-    - include_tasks: verify-role-results.yml
+    - name: Verify results
+      include_tasks: verify-role-results.yml


### PR DESCRIPTION
On EL7 the swap size must be less than 128GB, so change the tests
to restrict the size.  This required introducing a `max_size` parameter
to find_unused_disk.

I also took this opportunity to do some ansible-lint 6.x cleanup
for the code I touched.  There is still a huge amount of tests/
code that is not ansible-lint 6.x clean.
