### PR TITLE
fix: Allow using raid_chunk_size for RAID pools and volumes

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1745,7 +1745,8 @@ def run_module():
         dict(disks=dict(type='list'),
              raid_device_count=dict(type='int'),
              raid_spare_count=dict(type='int'),
-             raid_metadata_version=dict(type='str')))
+             raid_metadata_version=dict(type='str'),
+             raid_chunk_size=dict(type='str')))
     pool_volume_opts = copy.deepcopy(common_volume_opts)
     pool_volume_opts.update(
         dict(cached=dict(type='bool'),
@@ -1774,6 +1775,7 @@ def run_module():
                                 raid_device_count=dict(type='int'),
                                 raid_spare_count=dict(type='int'),
                                 raid_metadata_version=dict(type='str'),
+                                raid_chunk_size=dict(type='str'),
                                 state=dict(type='str', default='present', choices=['present', 'absent']),
                                 type=dict(type='str'),
                                 volumes=dict(type='list', elements='dict', default=list(),

--- a/tests/test-verify-volume-md.yml
+++ b/tests/test-verify-volume-md.yml
@@ -32,6 +32,25 @@
           regex_escape() }}"
       when: storage_test_volume.raid_metadata_version is defined
 
+    - name: Set chunk size regex
+      set_fact:
+        storage_test_md_chunk_size_re: "{{
+          storage_test_mdadm.stdout | regex_search('Chunk Size : ([0-9]+[KMG])',
+          '\\1') }}"
+      when:
+        - storage_test_volume.raid_chunk_size is defined
+        - storage_test_volume.raid_chunk_size is not none
+        - storage_test_volume.raid_chunk_size | string != "0 B"
+
+    - name: Parse the chunk size
+      bsize:
+        size: "{{ storage_test_md_chunk_size_re[0] }}"
+      register: storage_test_parsed_md_chunk_size
+      when:
+        - storage_test_volume.raid_chunk_size is defined
+        - storage_test_volume.raid_chunk_size is not none
+        - storage_test_volume.raid_chunk_size | string != "0 B"
+
     - name: Check RAID active devices count
       assert:
         that: storage_test_mdadm.stdout is
@@ -58,3 +77,13 @@
           Expected {{ storage_test_volume.raid_metadata_version }} RAID metadata
           version.
       when: storage_test_volume.raid_metadata_version is not none
+
+    - name: Check RAID chunk size
+      assert:
+        that: storage_test_parsed_md_chunk_size | int ==
+          storage_test_volume.raid_chunk_size | int
+        msg: Expected {{ storage_test_volume.raid_chunk_size }} RAID chunk size.
+      when:
+        - storage_test_volume.raid_chunk_size is defined
+        - storage_test_volume.raid_chunk_size is not none
+        - storage_test_volume.raid_chunk_size | string != "0 B"

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -117,3 +117,37 @@
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
+
+    - name: Create a RAID0 device
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            raid_level: "raid0"
+            raid_device_count: 3
+            raid_metadata_version: "1.0"
+            raid_chunk_size: "1024 KiB"
+            state: present
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Remove the pool created above
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            raid_level: "raid0"
+            raid_device_count: 3
+            raid_metadata_version: "1.0"
+            raid_chunk_size: "1024 KiB"
+            state: absent
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -83,3 +83,39 @@
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
+
+    - name: Create a RAID0 device mounted on "{{ mount_location }}"
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_volumes:
+          - name: test0
+            type: raid
+            raid_level: "raid0"
+            raid_device_count: 3
+            raid_metadata_version: "1.0"
+            raid_chunk_size: "1024K"
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+            state: present
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Remove the disk device created above
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_volumes:
+          - name: test0
+            type: raid
+            raid_level: "raid0"
+            raid_device_count: 3
+            raid_metadata_version: "1.0"
+            raid_chunk_size: "1024K"
+            disks: "{{ unused_disks }}"
+            mount_point: "{{ mount_location }}"
+            state: absent
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml

--- a/tests/verify-pool-md.yml
+++ b/tests/verify-pool-md.yml
@@ -32,6 +32,25 @@
           regex_escape() }}"
       when: storage_test_pool.raid_metadata_version is defined
 
+    - name: Set md chunk size regex
+      set_fact:
+        storage_test_md_chunk_size_re: "{{
+          storage_test_mdadm.stdout | regex_search('Chunk Size : ([0-9]+[KMG])',
+          '\\1') }}"
+      when:
+        - storage_test_pool.raid_chunk_size is defined
+        - storage_test_pool.raid_chunk_size is not none
+        - storage_test_pool.raid_chunk_size | string != "0 B"
+
+    - name: Parse the chunk size
+      bsize:
+        size: "{{ storage_test_md_chunk_size_re[0] }}"
+      register: storage_test_parsed_md_chunk_size
+      when:
+        - storage_test_pool.raid_chunk_size is defined
+        - storage_test_pool.raid_chunk_size is not none
+        - storage_test_pool.raid_chunk_size | string != "0 B"
+
     - name: Check RAID active devices count
       assert:
         that: storage_test_mdadm.stdout is
@@ -63,8 +82,19 @@
         - storage_test_pool.raid_metadata_version is defined
         - storage_test_pool.raid_metadata_version is not none
 
+    - name: Check RAID chunk size
+      assert:
+        that: storage_test_parsed_md_chunk_size | int ==
+          storage_test_pool.raid_chunk_size | int
+        msg: Expected {{ storage_test_pool.raid_chunk_size }} RAID chunk size.
+      when:
+        - storage_test_pool.raid_chunk_size is defined
+        - storage_test_pool.raid_chunk_size is not none
+        - storage_test_pool.raid_chunk_size | string != "0 B"
+
 - name: Reset variables used by tests
   set_fact:
     storage_test_md_active_devices_re: null
     storage_test_md_spare_devices_re: null
     storage_test_md_metadata_version_re: null
+    storage_test_md_chunk_size_re: null


### PR DESCRIPTION
Looks like we forgot `raid_chunk_size` when adding the pool/volume parameters checking.