### PR TITLE
feat: User-specified mount point owner and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ The `mount_point` specifies the directory on which the file system will be mount
 ##### `mount_options`
 The `mount_options` specifies custom mount options as a string, e.g.: 'ro'.
 
+##### `mount_user`
+The `mount_user` specifies desired owner of the mount directory.
+
+##### `mount_group`
+The `mount_group` specifies desired group of the mount directory.
+
+##### `mount_mode`
+The `mount_mode` specifies desired permissions of the mount directory.
+
 ##### `raid_level`
 Specifies RAID level. LVM RAID can be created as well.
 "Regular" RAID volume requires type to be `raid`.

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1632,7 +1632,10 @@ def get_mount_info(pools, volumes, actions, fstab):
                            'opts': volume['mount_options'],
                            'dump': volume['mount_check'],
                            'passno': volume['mount_passno'],
-                           'state': 'mounted' if volume['fs_type'] != "swap" else "present"})
+                           'state': 'mounted' if volume['fs_type'] != "swap" else "present",
+                           'owner': volume['mount_user'],
+                           'group': volume['mount_group'],
+                           'mode': volume['mount_mode']})
 
     return mount_info
 
@@ -1729,6 +1732,9 @@ def run_module():
                               fs_type=dict(type='str'),
                               mount_options=dict(type='str'),
                               mount_point=dict(type='str'),
+                              mount_user=dict(type='str'),
+                              mount_group=dict(type='str'),
+                              mount_mode=dict(type='str'),
                               name=dict(type='str'),
                               raid_level=dict(type='str'),
                               size=dict(type='str'),

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -139,11 +139,6 @@
   loop_control:
     loop_var: mount_info
 
-- name: Tell systemd to refresh its view of /etc/fstab
-  systemd:
-    daemon_reload: true
-  when: blivet_output['mounts']
-
 - name: Set up new/current mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
@@ -151,6 +146,21 @@
     fstype: "{{ mount_info['fstype'] | default(omit) }}"
     opts: "{{ mount_info['opts'] | default(omit) }}"
     state: "{{ mount_info['state'] }}"
+  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
+            rejectattr('state', 'match', '^absent$') | list }}"
+  loop_control:
+    loop_var: mount_info
+
+- name: Manage mount ownership/permissions
+  file:
+    path: "{{ mount_info['path'] }}"
+    owner: "{{ mount_info['owner'] if 'owner' in mount_info else omit }}"
+    group: "{{ mount_info['group'] if 'group' in mount_info else omit }}"
+    mode: "{{ mount_info['mode'] if 'mode' in mount_info else omit }}"
+    state: directory
+  when: mount_info['owner'] != none or
+        mount_info['group'] != none or
+        mount_info['mode'] != none
   loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
             rejectattr('state', 'match', '^absent$') | list }}"
   loop_control:

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -30,6 +30,16 @@
       _storage_test_volume_present and
       storage_test_volume.fs_type == 'swap' else 0 }}"
 
+- name: Get information about the mountpoint directory
+  stat:
+    path: "{{ storage_test_volume.mount_point }}"
+  register: storage_test_found_mount_stat
+  when: _storage_test_volume_present and
+        storage_test_volume.mount_point and
+        (storage_test_volume.mount_user or
+         storage_test_volume.mount_group or
+         storage_test_volume.mount_mode)
+
 #
 # Verify mount presence.
 #
@@ -43,7 +53,7 @@
   when: _storage_test_volume_present and storage_test_volume.mount_point
 
 #
-# Verify mount directory.
+# Verify mount directory (state, owner, group, permissions).
 #
 - name: Verify the current mount state by mount point
   assert:
@@ -52,6 +62,42 @@
     msg: >-
       Found unexpected mount state for volume
       '{{ storage_test_volume.name }}' mount point
+
+- name: Verify mount directory user
+  assert:
+    that: storage_test_volume.mount_user ==
+          storage_test_found_mount_stat.stat.pw_name
+    msg: "Mount directory {{ storage_test_volume.mount_point }} of volume
+          {{ storage_test_volume.name }}) has unexpected owner
+          (expected: {{ storage_test_volume.mount_user }}, found:
+          {{ storage_test_found_mount_stat.stat.pw_name }})"
+  when: _storage_test_volume_present and
+        storage_test_volume.mount_point and
+        storage_test_volume.mount_user
+
+- name: Verify mount directory group
+  assert:
+    that: storage_test_volume.mount_group ==
+          storage_test_found_mount_stat.stat.gr_name
+    msg: "Mount directory {{ storage_test_volume.mount_point }} of volume
+          {{ storage_test_volume.name }}) has unexpected group
+          (expected: {{ storage_test_volume.mount_group }}, found:
+          {{ storage_test_found_mount_stat.stat.gr_name }})"
+  when: _storage_test_volume_present and
+        storage_test_volume.mount_point and
+        storage_test_volume.mount_group
+
+- name: Verify mount directory permissions
+  assert:
+    that: storage_test_volume.mount_mode ==
+          storage_test_found_mount_stat.stat.mode
+    msg: "Mount directory {{ storage_test_volume.mount_point }} of volume
+          {{ storage_test_volume.name }}) has unexpected permissions (expected:
+          {{ storage_test_volume.mount_mode }}, found:
+          {{ storage_test_found_mount_stat.stat.mode }})"
+  when: _storage_test_volume_present and
+        storage_test_volume.mount_point and
+        storage_test_volume.mount_mode
 
 #
 # Verify mount fs type.
@@ -100,3 +146,4 @@
     storage_test_swap_expected_matches: null
     storage_test_sys_node: null
     storage_test_swaps: null
+    storage_test_found_mount_stat: null

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -35,6 +35,9 @@
             disks: "{{ unused_disks[0] }}"
             fs_type: ext4
             mount_point: "{{ mount_location }}"
+            mount_user: "nobody"
+            mount_group: "nobody"
+            mount_mode: "0777"
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
@@ -48,6 +51,9 @@
             type: disk
             disks: "{{ unused_disks }}"
             mount_point: "{{ mount_location }}"
+            mount_user: "root"
+            mount_group: "root"
+            mount_mode: "0755"
 
     - name: Assert file system is preserved on existing partition volume
       assert:


### PR DESCRIPTION
Added new volume options related to mount point directory: mount_user - directory owner (string)
mount_group - directory group (string)
mount_permissions - directory permissions (string; same format as chmod)

Resolves: rhbz#2181661