### PR TITLE
feat: Add support for setting stripe size for LVM RAID

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ When type is `raid` specifies RAID metadata version as a string, e.g.: '1.0'.
 When type is `raid` specifies RAID chunk size as a string, e.g.: '512 KiB'.
 Chunk size has to be multiple of 4 KiB.
 
+When type is `lvm` specifies RAID stripes size instead.
+
 ##### `raid_disks`
 Specifies which disks should be used for LVM RAID volume.
 `raid_level` needs to be specified and volume has to have `storage_pools` parent with type `lvm`.

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -760,7 +760,11 @@ class BlivetLVMVolume(BlivetVolume):
         else:
             pvs = parent_device.pvs
 
-        return dict(seg_type=self._volume['raid_level'], pvs=pvs)
+        # get stripe size (chunk size in our terminology)
+        stripe_size = self._spec_dict.get("raid_chunk_size")
+        stripe_size = Size(stripe_size) if stripe_size is not None else None
+
+        return dict(seg_type=self._volume['raid_level'], pvs=pvs, stripe_size=stripe_size)
 
     def _detach_cache(self):
         """ Detach cache from the volume and remove the unused cache pool """
@@ -1749,6 +1753,7 @@ def run_module():
              compression=dict(type='bool'),
              deduplication=dict(type='bool'),
              raid_disks=dict(type='list', elements='str', default=list()),
+             raid_chunk_size=dict(type='str'),
              thin_pool_name=dict(type='str'),
              thin_pool_size=dict(type='str'),
              thin=dict(type='bool', default=False),

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -26,6 +26,32 @@
           - packages_installed
           - service_facts
 
+    - name: Gather package facts
+      package_facts:
+
+    - name: Set blivet package name
+      set_fact:
+        blivet_pkg_name: "{{ ansible_facts.packages |
+          select('search', 'blivet') | select('search', 'python') | list }}"
+
+    - name: Set blivet package version
+      set_fact:
+        blivet_pkg_version: "{{
+          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
+          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
+
+    - name: Set distribution version
+      set_fact:
+        is_rhel9: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'Enterprise Linux' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version == '9' }}"
+        is_rhel8: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'Enterprise Linux' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version == '8' }}"
+        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
+
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
       vars:
@@ -217,3 +243,47 @@
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
+
+    - name: Run test on supported platforms
+      when: ((is_fedora and blivet_pkg_version is version("3.7.1-2", ">=")) or
+             (is_rhel8 and blivet_pkg_version is version("3.6.0-5", ">=")) or
+             (is_rhel9 and blivet_pkg_version is version("3.6.0-6", ">=")))
+      block:
+        - name: Create a RAID0 lvm raid device with custom chunk (stripe) size
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                    raid_level: raid0
+                    raid_chunk_size: "256 KiB"
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Remove the device created above
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: absent
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_level: raid0
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml

--- a/tests/verify-pool-member-lvmraid.yml
+++ b/tests/verify-pool-member-lvmraid.yml
@@ -5,21 +5,50 @@
     - storage_test_pool.state != "absent"
     - storage_test_lvmraid_volume.state != "absent"
   block:
-    - name: Get information about LVM RAID
-      # yamllint disable rule:line-length
-      command: >-
-        lvs --noheading -o lv_name --select
-        'lv_name={{ storage_test_lvmraid_volume.name }}&&lv_layout={{ storage_test_lvmraid_volume.raid_level }}'
-        {{ storage_test_pool.name }}
-      register: storage_test_lvmraid_status
+    - name: Get information about the LV
+      command: >
+          lvs --noheadings --nameprefixes --units=b --nosuffix --unquoted
+          -o name,segtype,stripe_size
+          {{ storage_test_pool.name }}/{{ storage_test_lvmraid_volume.name }}
+      register: lvs
       changed_when: false
-      # yamllint enable rule:line-length
 
-    - name: Check that volume is LVM RAID
+    - name: Set LV segment type
+      set_fact:
+        storage_test_lv_segtype: "{{ lvs.stdout |
+          regex_search('LVM2_SEGTYPE=(\\S+)', '\\1') }}"
+
+    - name: Check segment type
       assert:
-        that: storage_test_lvmraid_status.stdout | trim ==
-          storage_test_lvmraid_volume.name
+        that: storage_test_lv_segtype[0] ==
+              storage_test_lvmraid_volume.raid_level
+        msg: >-
+          Unexpected segtype {{ storage_test_lv_segtype }}
+          for {{ storage_test_lvmraid_volume.name }}
 
-- name: Reset variable used by test
-  set_fact:
-    storage_test_lvmraid_status: null
+    - name: Set LV stripe size
+      set_fact:
+        storage_test_lv_stripe_size: "{{ lvs.stdout |
+          regex_search('LVM2_STRIPE_SIZE=(\\S+)', '\\1') }}"
+
+    - name: Parse the requested stripe (chunk) size
+      bsize:
+        size: "{{ storage_test_lvmraid_volume.raid_chunk_size }}"
+      register: storage_test_requested_stripe_size
+      when: storage_test_lvmraid_volume.raid_chunk_size is not none
+
+    - name: Set expected stripe size
+      set_fact:
+        storage_test_expected_stripe_size: "{{
+          storage_test_requested_stripe_size.bytes }}"
+      when: storage_test_lvmraid_volume.raid_chunk_size is not none
+
+    - name: Check stripe size
+      assert:
+        that: storage_test_expected_stripe_size | int ==
+              storage_test_lv_stripe_size[0] | int
+        msg: >
+            Unexpected stripe size, expected
+            {{ storage_test_expected_stripe_size }},
+            got {{ storage_test_lv_stripe_size[0] }}
+      when: storage_test_lvmraid_volume.raid_chunk_size is not none


### PR DESCRIPTION
Custom stripe size is needed for SAP HANA. We are using here the existing 'raid_chunk_size' property, the "chunk size" term comes from MD RAID where it has the same meaning as "stripe size" for LVM RAID.