### PR TITLE
fix: add back systemd refresh after remove obsolete mounts

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -139,6 +139,11 @@
   loop_control:
     loop_var: mount_info
 
+- name: Tell systemd to refresh its view of /etc/fstab
+  systemd:
+    daemon_reload: true
+  when: blivet_output['mounts']
+
 - name: Set up new/current mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"


### PR DESCRIPTION
Turns out that the systemd refresh removed as part of
https://github.com/linux-system-roles/storage/pull/352
was needed.  This fix adds it back.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
