### PR TITLE
test: use SYSTEM_ROLES_REMOVE_CLOUD_INIT=1 with remove-cloud-init

### DIFF
--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -19,7 +19,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_change_disk_mount.yml
+++ b/tests/tests_change_disk_mount.yml
@@ -16,7 +16,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -21,7 +21,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -22,7 +22,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_change_mount.yml
+++ b/tests/tests_change_mount.yml
@@ -18,7 +18,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -15,8 +15,10 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
           - service_facts
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -22,7 +22,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_create_lvm_cache_then_remove.yml
+++ b/tests/tests_create_lvm_cache_then_remove.yml
@@ -20,7 +20,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Gather package facts

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -21,7 +21,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -21,7 +21,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Gather package facts

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -15,7 +15,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -23,7 +23,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -16,7 +16,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -16,7 +16,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_existing_lvm_pool.yml
+++ b/tests/tests_existing_lvm_pool.yml
@@ -19,7 +19,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_fatals_cache_volume.yml
+++ b/tests/tests_fatals_cache_volume.yml
@@ -19,7 +19,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_fatals_raid_pool.yml
+++ b/tests/tests_fatals_raid_pool.yml
@@ -23,7 +23,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_fatals_raid_volume.yml
+++ b/tests/tests_fatals_raid_volume.yml
@@ -16,7 +16,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_filesystem_one_disk.yml
+++ b/tests/tests_filesystem_one_disk.yml
@@ -14,7 +14,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -53,7 +53,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Test key file handling

--- a/tests/tests_lvm_auto_size_cap.yml
+++ b/tests/tests_lvm_auto_size_cap.yml
@@ -13,7 +13,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -23,7 +23,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -18,7 +18,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_lvm_one_disk_multiple_volumes.yml
+++ b/tests/tests_lvm_one_disk_multiple_volumes.yml
@@ -17,7 +17,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_lvm_one_disk_one_volume.yml
+++ b/tests/tests_lvm_one_disk_one_volume.yml
@@ -18,7 +18,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -19,7 +19,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Gather package facts

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -21,7 +21,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks for test

--- a/tests/tests_missing_volume_type_in_pool.yml
+++ b/tests/tests_missing_volume_type_in_pool.yml
@@ -15,7 +15,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_null_raid_pool.yml
+++ b/tests/tests_null_raid_pool.yml
@@ -19,7 +19,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -23,7 +23,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -16,7 +16,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_remove_mount.yml
+++ b/tests/tests_remove_mount.yml
@@ -18,7 +18,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -20,7 +20,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -26,7 +26,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_safe_mode_check.yml
+++ b/tests/tests_safe_mode_check.yml
@@ -21,7 +21,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -15,7 +15,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     # rhel7 has a limitation of 128g swap size

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -16,7 +16,9 @@
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - packages_installed
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
           - service_facts
 
     - name: Get unused disks


### PR DESCRIPTION
When testing with qemu and `--remove-cloud-init`, some of the tests
will fail because of missing packages.  However, if you define
`SYSTEM_ROLES_REMOVE_CLOUD_INIT=1` environment variable, you will
let the storage role determine which packages should be installed
and install them, which is the default.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
