### PR TITLE
test: enable FIPS testing; configurable LUKS cipher

### DIFF
--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -6,9 +6,50 @@
     mount_location: '/opt/test1'
     testfile: "{{ mount_location }}/quux"
     volume_size: '5g'
+    __luks_cipher: "{{ (__luks_cipher_env == '') |
+      ternary('aes-xts-plain64', __luks_cipher_env) }}"
+    __luks_cipher_env: "{{ lookup('env', 'SYSTEM_ROLES_LUKS_CIPHER') }}"
   tags:
     - tests::lvm
   tasks:
+    - name: Enable FIPS mode
+      when:
+        - lookup("env", "SYSTEM_ROLES_TEST_FIPS") == "true"
+        - ansible_facts["os_family"] == "RedHat"
+        - ansible_facts["distribution_major_version"] | int > 7
+      block:
+        - name: Enable FIPS mode
+          command: fips-mode-setup --enable
+          changed_when: false
+
+        - name: Reboot
+          reboot:
+            test_command: fips-mode-setup --check
+
+    - name: Enable FIPS mode
+      when:
+        - lookup("env", "SYSTEM_ROLES_TEST_FIPS") == "true"
+        - ansible_facts["os_family"] == "RedHat"
+        - ansible_facts["distribution_major_version"] | int == 7
+      block:
+        - name: Ensure dracut-fips
+          package:
+            name: dracut-fips
+            state: present
+
+        - name: Configure boot for FIPS
+          changed_when: false
+          shell: |
+            set -euxo pipefail
+            mv -v /boot/initramfs-$(uname -r).img{,.bak}
+            dracut
+            kernel=$(grubby --default-kernel)
+            grubby --update-kernel=$kernel --args=fips=1
+
+        - name: Reboot
+          reboot:
+            test_command: grep 1 /proc/sys/crypto/fips_enabled
+
     - name: Run the role
       include_role:
         name: linux-system-roles.storage
@@ -328,7 +369,7 @@
                 encryption_password: yabbadabbadoo
                 encryption_luks_version: luks1
                 encryption_key_size: 512
-                encryption_cipher: serpent-xts-plain64
+                encryption_cipher: "{{ __luks_cipher }}"
 
     - name: Verify role results
       include_tasks: verify-role-results.yml

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -8,10 +8,51 @@
     testfile: "{{ mount_location }}/quux"
     testfile_location_2: "{{ mount_location_2 }}/quux"
     volume_size: '5g'
+    __luks_cipher: "{{ (__luks_cipher_env == '') |
+      ternary('aes-xts-plain64', __luks_cipher_env) }}"
+    __luks_cipher_env: "{{ lookup('env', 'SYSTEM_ROLES_LUKS_CIPHER') }}"
   tags:
     - tests::lvm
 
   tasks:
+    - name: Enable FIPS mode
+      when:
+        - lookup("env", "SYSTEM_ROLES_TEST_FIPS") == "true"
+        - ansible_facts["os_family"] == "RedHat"
+        - ansible_facts["distribution_major_version"] | int > 7
+      block:
+        - name: Enable FIPS mode
+          command: fips-mode-setup --enable
+          changed_when: false
+
+        - name: Reboot
+          reboot:
+            test_command: fips-mode-setup --check
+
+    - name: Enable FIPS mode
+      when:
+        - lookup("env", "SYSTEM_ROLES_TEST_FIPS") == "true"
+        - ansible_facts["os_family"] == "RedHat"
+        - ansible_facts["distribution_major_version"] | int == 7
+      block:
+        - name: Ensure dracut-fips
+          package:
+            name: dracut-fips
+            state: present
+
+        - name: Configure boot for FIPS
+          changed_when: false
+          shell: |
+            set -euxo pipefail
+            mv -v /boot/initramfs-$(uname -r).img{,.bak}
+            dracut
+            kernel=$(grubby --default-kernel)
+            grubby --update-kernel=$kernel --args=fips=1
+
+        - name: Reboot
+          reboot:
+            test_command: grep 1 /proc/sys/crypto/fips_enabled
+
     - name: Run the role
       include_role:
         name: linux-system-roles.storage
@@ -161,7 +202,7 @@
               encryption_password: yabbadabbadoo
               encryption_luks_version: luks1
               encryption_key_size: 512
-              encryption_cipher: serpent-xts-plain64
+              encryption_cipher: "{{ __luks_cipher }}"
               volumes:
                 - name: test1
                   mount_point: "{{ mount_location }}"
@@ -183,7 +224,7 @@
             encryption_password: yabbadabbadoo
             encryption_luks_version: luks1
             encryption_key_size: 512
-            encryption_cipher: serpent-xts-plain64
+            encryption_cipher: "{{ __luks_cipher }}"
             volumes:
               - name: test1
                 mount_point: "{{ mount_location }}"


### PR DESCRIPTION
Can test with FIPS by setting the environment variable
`SYSTEM_ROLES_TEST_FIPS=true` before running the LUKS tests.
Can set the LUKS cipher with `SYSTEM_ROLES_LUKS_CIPHER` - the
default is `aes-xts-plain64`
Signed-off-by: Rich Megginson <rmeggins@redhat.com>
