### PR TITLE
test: use storage_safe_mode_arg for verify-role-failed argument

### DIFF
--- a/tests/tests_fatals_cache_volume.yml
+++ b/tests/tests_fatals_cache_volume.yml
@@ -30,10 +30,15 @@
         max_return: 2
         disks_needed: 2
 
+    - name: Set safe mode arg
+      set_fact:
+        storage_safe_mode_arg: "{{ storage_safe_mode }}"
+
     - name: Verify that creating a cached partition volume fails
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: "{{ unused_disks[0] }}"
               type: partition
@@ -47,6 +52,7 @@
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               disks: "{{ [unused_disks[0]] }}"

--- a/tests/tests_fatals_raid_pool.yml
+++ b/tests/tests_fatals_raid_pool.yml
@@ -34,10 +34,15 @@
         max_return: 2
         disks_needed: 2
 
+    - name: Set safe mode arg
+      set_fact:
+        storage_safe_mode_arg: "{{ storage_safe_mode }}"
+
     - name: Try to create a raid pool with invalid raid_level (expect failure)
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: vg1
               disks: "{{ unused_disks }}"

--- a/tests/tests_fatals_raid_volume.yml
+++ b/tests/tests_fatals_raid_volume.yml
@@ -27,12 +27,16 @@
         max_return: 2
         disks_needed: 2
 
+    - name: Set safe mode arg
+      set_fact:
+        storage_safe_mode_arg: "{{ storage_safe_mode }}"
+
     - name: Try to create a raid pool with invalid raid_level (expect failure)
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_exception: RAID level null is an invalid value.
         __storage_failed_params:
-          storage_safe_mode: false
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_volumes:
             - name: test1
               type: raid

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -24,6 +24,10 @@
         min_size: "{{ volume_group_size }}"
         max_return: 1
 
+    - name: Set storage_safe_mode_arg
+      set_fact:
+        storage_safe_mode_arg: "{{ storage_safe_mode }}"
+
     - name: >-
         Test for correct handling of invalid percentage-based size
         specification.
@@ -33,6 +37,7 @@
         __storage_failed_msg: >-
           Unexpected error message output from invalid percentage size input
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               disks: "{{ unused_disks }}"

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -63,6 +63,10 @@
     - name: Verify results
       include_tasks: verify-role-results.yml
 
+    - name: Set safe mode arg
+      set_fact:
+        storage_safe_mode_arg: "{{ storage_safe_mode }}"
+
     - name: >-
         Test for correct handling of invalid parameter when creating ext4
         filesystem
@@ -75,6 +79,7 @@
           Unexpected behavior when creating ext4 filesystem with invalid
           parameter
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               type: lvm
@@ -123,6 +128,7 @@
         __storage_failed_msg: >-
           Unexpected behavior when resizing with large size
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               type: lvm
@@ -212,6 +218,7 @@
         __storage_failed_msg: >-
           Unexpected behavior when mount swap filesystem
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_volumes:
             - name: test1
               type: disk

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -93,6 +93,10 @@
     - name: Verify role results
       include_tasks: verify-role-results.yml
 
+    - name: Set storage_safe_mode_arg
+      set_fact:
+        storage_safe_mode_arg: "{{ storage_safe_mode }}"
+
     - name: Test for correct handling of too-large volume size
       include_tasks: verify-role-failed.yml
       vars:
@@ -100,6 +104,7 @@
         __storage_failed_msg: >-
           Unexpected behavior w/ invalid volume size
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               disks: "{{ unused_disks }}"
@@ -136,6 +141,7 @@
         __storage_failed_msg: >-
           Unexpected behavior w/ invalid volume size
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               disks: "{{ unused_disks }}"
@@ -152,6 +158,7 @@
         __storage_failed_msg: >-
           Unexpected behavior w/ invalid volume size
         __storage_failed_params:
+          storage_safe_mode: "{{ storage_safe_mode_arg }}"
           storage_pools:
             - name: foo
               disks: "{{ unused_disks }}"
@@ -393,6 +400,7 @@
             __storage_failed_msg: >-
               Unexpected behavior w/ resize in safe mode
             __storage_failed_params:
+              storage_safe_mode: "{{ storage_safe_mode_arg }}"
               storage_pools:
                 - name: foo
                   disks: "{{ unused_disks }}"

--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -1,10 +1,6 @@
 ---
 - name: Verify role raises correct error
   block:
-    - name: Store global variable value copy
-      set_fact:
-        storage_safe_mode_global: "{{ storage_safe_mode }}"
-
     - name: Verify role raises correct error
       include_role:
         name: linux-system-roles.storage
@@ -14,8 +10,7 @@
         storage_volumes: "{{
           __storage_failed_params.get('storage_volumes', []) }}"
         storage_safe_mode: "{{
-          __storage_failed_params.get('storage_safe_mode',
-          storage_safe_mode_global) }}"
+          __storage_failed_params.get('storage_safe_mode', true) }}"
 
     - name: Unreachable task
       fail:


### PR DESCRIPTION
Some tests want to set `storage_safe_mode` globally for all use
cases in the test.  However, this doesn't work with
`verify-role-failed.yml` because you can't do

```yaml
include_tasks: verify-role-failed.yml
vars:
  storage_safe_mode: "{{ storage_safe_mode }}"
```

and also because `verify-role-failed.yml` requires an explicit
`storage_safe_mode` argument.

So, use an intermediate variable `storage_safe_mode_arg` to hold the "global"
setting of `storage_safe_mode` to pass to `verify-role-failed.yml`:

```yaml
include_tasks: verify-role-failed.yml
vars:
  storage_safe_mode: "{{ storage_safe_mode_arg }}"
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>