### PR TITLE
test: fix undefined storage_safe_mode

### DIFF
--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -393,6 +393,7 @@
             __storage_failed_msg: >-
               Unexpected behavior w/ resize in safe mode
             __storage_failed_params:
+              storage_safe_mode: true
               storage_pools:
                 - name: foo
                   disks: "{{ unused_disks }}"

--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -3,16 +3,20 @@
   block:
     - name: Store global variable value copy
       set_fact:
-        storage_safe_mode_global: "{{ storage_safe_mode }}"
+        storage_safe_mode_global: "{{ storage_safe_mode | d(true) }}"
+        storage_pools_global: "{{ storage_pools | d([]) }}"
+        storage_volumes_global: "{{ storage_volumes | d([]) }}"
 
     - name: Verify role raises correct error
       include_role:
         name: linux-system-roles.storage
       vars:
         storage_pools: "{{
-          __storage_failed_params.get('storage_pools', []) }}"
+          __storage_failed_params.get('storage_pools',
+          storage_pools_global) }}"
         storage_volumes: "{{
-          __storage_failed_params.get('storage_volumes', []) }}"
+          __storage_failed_params.get('storage_volumes',
+          storage_volumes_global) }}"
         storage_safe_mode: "{{
           __storage_failed_params.get('storage_safe_mode',
           storage_safe_mode_global) }}"


### PR DESCRIPTION
Tests are failing if storage_safe_mode is not defined in the test.
Ensure it has a default value `true`.
Also ensure that we can use a global `storage_pools` and
`storage_volumes`.
Signed-off-by: Rich Megginson <rmeggins@redhat.com>
