### PR TITLE
fix: Add libblockdev-nvme to blivet dependencies on RHEL/CentOS 9

### DIFF
--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -5,6 +5,7 @@ blivet_package_list:
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-mdraid
+  - libblockdev-nvme
   - libblockdev-swap
   - vdo
   - kmod-kvdo

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -5,6 +5,7 @@ blivet_package_list:
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-mdraid
+  - libblockdev-nvme
   - libblockdev-swap
   - vdo
   - kmod-kvdo

--- a/vars/Rocky_9.yml
+++ b/vars/Rocky_9.yml
@@ -5,6 +5,7 @@ blivet_package_list:
   - libblockdev-dm
   - libblockdev-lvm
   - libblockdev-mdraid
+  - libblockdev-nvme
   - libblockdev-swap
   - vdo
   - kmod-kvdo


### PR DESCRIPTION
On RHEL blivet now also uses libblockdev NVMe plugin so we should
add it as a dependency here as well.

Fixes: #382
