### PR TITLE
chore: Add support for AlmaLinux 8 & 9

### DIFF
--- a/vars/AlmaLinux_8.yml
+++ b/vars/AlmaLinux_8.yml
@@ -1,0 +1,11 @@
+---
+blivet_package_list:
+  - python3-blivet
+  - libblockdev-crypto
+  - libblockdev-dm
+  - libblockdev-lvm
+  - libblockdev-mdraid
+  - libblockdev-swap
+  - vdo
+  - kmod-kvdo
+  - xfsprogs

--- a/vars/AlmaLinux_9.yml
+++ b/vars/AlmaLinux_9.yml
@@ -1,0 +1,11 @@
+---
+blivet_package_list:
+  - python3-blivet
+  - libblockdev-crypto
+  - libblockdev-dm
+  - libblockdev-lvm
+  - libblockdev-mdraid
+  - libblockdev-swap
+  - vdo
+  - kmod-kvdo
+  - xfsprogs


### PR DESCRIPTION
Enhancement: Add full support for AlmaLinux 8 & 9. This replaces the (abandoned) pull request at https://github.com/linux-system-roles/storage/pull/211 and fixes https://github.com/linux-system-roles/storage/issues/239.

Reason: It's currently not supported.

Result: Works fine on many production systems.