### PR TITLE
ci: update github action checkout to v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Use v4 github action checkout
Update dependabot to include the "ci: " prefix in commit/pr titles
for PR title checking.
Tell dependabot to check weekly instead of monthly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
