### PR TITLE
fix: Do not remove swap at every run

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1647,8 +1647,6 @@ def get_mount_info(pools, volumes, actions, fstab):
         # handle removal of existing mounts of this volume
         if mount and mount['fs_type'] != 'swap' and mount['mount_point'] != volume['mount_point']:
             replace = dict(path=mount['mount_point'], state="absent")
-        elif mount and mount['fs_type'] == 'swap':
-            replace = dict(src=mount['device_id'], fstype="swap", path="none", state="absent")
 
         return mounted, replace
 


### PR DESCRIPTION
Enhancement: The role is not idempotent if the system has swap. At every execution, the swap entries are remove and re-added in the next task.

Reason: There is specific code that deletes swap unconditionally. I could not find any apparent real reason for this piece of code to exist.

Result: Role is idempotent.