### PR TITLE
feat: Support for creating volumes without a FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ variables:
   This indicates the desired file system type to use, e.g.: "xfs", "ext4", "swap".
   The default is determined according to the OS and release
   (currently `xfs` for all the supported systems).
+  Use "unformatted" if you do not want file system to be present.
+  __WARNING__: Using "unformatted" file system type on an existing filesystem
+               is a destructive operation and will destroy all data on the volume.
 
 - `fs_label`
 

--- a/tests/test-verify-volume-fs.yml
+++ b/tests/test-verify-volume-fs.yml
@@ -3,7 +3,9 @@
 - name: Verify fs type
   assert:
     that: storage_test_blkinfo.info[storage_test_volume._device].fstype ==
-      storage_test_volume.fs_type
+      storage_test_volume.fs_type or
+      (storage_test_blkinfo.info[storage_test_volume._device].fstype | length
+       == 0 and storage_test_volume.fs_type == "unformatted")
   when: storage_test_volume.fs_type and _storage_test_volume_present
 
 # label

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -101,6 +101,22 @@
     - name: Verify role results
       include_tasks: verify-role-results.yml
 
+    - name: Remove the FS
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                fs_type: unformatted
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+
     - name: Clean up
       include_role:
         name: linux-system-roles.storage


### PR DESCRIPTION
Currently whenever volume is created without fs_type specification, a filesystem of default type (i.e. xfs) is automatically put on it.
This change allows user to prevent FS creation by using "unformatted" value as a fs_type option. In the same manner it also allows to remove an existing FS. To be able to do that the safe mode has to be off.

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
