### PR TITLE
Update enable_coprs.yml

### DIFF
--- a/tasks/enable_coprs.yml
+++ b/tasks/enable_coprs.yml
@@ -17,7 +17,7 @@
     use: "{{ (__storage_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: 
-    - _storage_copr_packages is defined
+    - _storage_copr_support_packages is defined
     - install_copr | d(false) | bool
 
 - name: Enable COPRs

--- a/tasks/enable_coprs.yml
+++ b/tasks/enable_coprs.yml
@@ -1,3 +1,4 @@
+
 ---
 - name: Check if the COPR support packages should be installed
   set_fact:
@@ -15,7 +16,9 @@
     name: "{{ _storage_copr_support_packages }}"
     use: "{{ (__storage_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: install_copr | d(false) | bool
+  when: 
+    - _storage_copr_packages is defined
+    - install_copr | d(false) | bool
 
 - name: Enable COPRs
   include_tasks: enable_copr.yml


### PR DESCRIPTION
Add missing "when" statement

Enhancement:

This adds a "when" statement that is missing.

Reason:

The 1st and 3rd task check whether the variable is defined, but the 2nd does not. Therefore if the variable is not defined this task file's execution will fail at the 2nd task and the check that is part of the 3rd task will never have any effect.

Result:

Execution will no longer fail at the 2nd task if the variable is not defined, instead it will continue to the third which then again checks whether the variable is defined.

Issue Tracker Tickets (Jira or BZ if any):
