### PR TITLE
feat: Enable GFS2 support in blivet

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -110,7 +110,6 @@ options:
                     fs_label:
                         description: fs_label
                         type: str
-                        default: ''
                     fs_type:
                         description: fs_type
                         type: str
@@ -216,7 +215,6 @@ options:
             fs_label:
                 description: fs_label
                 type: str
-                default: ''
             fs_type:
                 description: fs_type
                 type: str
@@ -2091,7 +2089,7 @@ def run_module():
                               encryption_luks_version=dict(type='str'),
                               encryption_password=dict(type='str', no_log=True),
                               fs_create_options=dict(type='str'),
-                              fs_label=dict(type='str', default=''),
+                              fs_label=dict(type='str'),
                               fs_type=dict(type='str'),
                               mount_options=dict(type='str'),
                               mount_point=dict(type='str'),

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -412,6 +412,7 @@ from ansible.module_utils.storage_lsr.argument_validator import validate_paramet
 if BLIVET_PACKAGE:
     blivet_flags.debug = True
     blivet_flags.allow_online_fs_resize = True
+    blivet_flags.gfs2 = True
     set_up_logging()
     log = logging.getLogger(BLIVET_PACKAGE + ".ansible")
 

--- a/tests/test-verify-volume-fs.yml
+++ b/tests/test-verify-volume-fs.yml
@@ -18,4 +18,9 @@
       should
       ('{{ storage_test_blkinfo.info[storage_test_volume._device].label }}',
       '{{ storage_test_volume.fs_label }}')
-  when: _storage_test_volume_present | bool
+  when:
+    - _storage_test_volume_present | bool
+    # label for GFS2 is set manually with the extra `-t` fs_create_options
+    # so we can't verify it here because it was not set with fs_label so
+    # the label from blkinfo doesn't match the expected "empty" fs_label
+    - storage_test_volume.fs_type != "gfs2"

--- a/tests/tests_lvm_pool_shared.yml
+++ b/tests/tests_lvm_pool_shared.yml
@@ -127,7 +127,7 @@
                     size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
                     fs_type: gfs2
-                    fs_create_options: -p lock_nolock
+                    fs_create_options: -j 2 -t rhel9-1node:myfs
 
         - name: Verify role results
           include_tasks: verify-role-results.yml
@@ -147,7 +147,7 @@
                     size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
                     fs_type: gfs2
-                    fs_create_options: -p lock_nolock
+                    fs_create_options: -j 2 -t rhel9-1node:myfs
 
         - name: Verify role results
           include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_pool_shared.yml
+++ b/tests/tests_lvm_pool_shared.yml
@@ -126,6 +126,8 @@
                   - name: lv1
                     size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
+                    fs_type: gfs2
+                    fs_create_options: -p lock_nolock
 
         - name: Verify role results
           include_tasks: verify-role-results.yml
@@ -144,6 +146,8 @@
                   - name: lv1
                     size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
+                    fs_type: gfs2
+                    fs_create_options: -p lock_nolock
 
         - name: Verify role results
           include_tasks: verify-role-results.yml

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -77,6 +77,40 @@
     - name: Verify role results
       include_tasks: verify-role-results.yml
 
+    - name: Relabel without explicitly setting the label
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            mount_point: "{{ mount_location }}"
+            fs_type: ext4
+            disks: "{{ unused_disks }}"
+
+    - name: Check for default value
+      assert:
+        that: not blivet_output.changed
+        msg: "Volume relabeling doesn't preserve existing label."
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Remove label
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            mount_point: "{{ mount_location }}"
+            fs_type: ext4
+            disks: "{{ unused_disks }}"
+            fs_label: ""
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
     - name: Clean up
       include_role:
         name: linux-system-roles.storage


### PR DESCRIPTION
GFS2 is supported by blivet, but the support is disabled by default so we need to enable it.

Fixes: #417