### PR TITLE
test: disk size is ok if less than 4 percent of expected

### DIFF
--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -164,7 +164,7 @@
 - name: Assert expected size is actual size
   assert:
     that: (storage_test_expected_size | int - storage_test_actual_size.bytes) |
-      abs / storage_test_expected_size | int < 0.02
+      abs / storage_test_expected_size | int < 0.04
     msg: >-
       Volume {{ storage_test_volume.name }} has unexpected size
       (expected: {{ storage_test_expected_size | int }} /


### PR DESCRIPTION
QE reported a test failure like this:
```
TASK [Show actual size] ********************************************************
ok: [localhost] => {
    "storage_test_actual_size": {
        "bytes": 1649267441664,
        "changed": false,
        "failed": false,
        "lvm": "1t",
        "parted": "1TiB",
        "size": "1 TiB"
    }
}

TASK [Show expected size] ******************************************************
ok: [localhost] => {
    "storage_test_expected_size": "1600321314816"
}

TASK [Assert expected size is actual size] *************************************
fatal: [localhost]: FAILED! => {
    "assertion": "(storage_test_expected_size | int - storage_test_actual_size.bytes) | abs / storage_test_expected_size | int < 0.02",
    "changed": false,
    "evaluated_to": false,
    "msg": "Volume test1 has unexpected size (expected: 1600321314816 / actual: 1649267441664)"
}

PLAY RECAP *********************************************************************
```

In this case,
```
>>> abs(1600321314816-1649267441664)/1600321314816
0.03058518710889486
```
I think this is correct, so raising the percentage to check to 4.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
