### PR TITLE
test: skip lvm pool shared test if not supported

### DIFF
--- a/tests/tests_lvm_pool_shared.yml
+++ b/tests/tests_lvm_pool_shared.yml
@@ -10,6 +10,10 @@
     lvm_conf: /etc/lvm/lvm.conf
 
   tasks:
+    - name: Skip this test if test system does not support
+      meta: end_host
+      when: lookup("env", "SYSTEM_ROLES_STORAGE_SHARED_TEST") != "true"
+
     - name: Run the test
       block:
         - name: See if lvm.conf exists


### PR DESCRIPTION
Our CI and local test frameworks do not currently support the
shared lvm pool test.  Skip it by default.
If you want to run the test, set the environment variable
`SYSTEM_ROLES_STORAGE_SHARED_TEST=true` in your
`ansible-playbook` invocation environment e.g.
`SYSTEM_ROLES_STORAGE_SHARED_TEST=true ansible-playbook ... tests_lvm_pool_shared.yml`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
