### PR TITLE
test: fix sector-based disk size calculation from ansible_devices

### DIFF
--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -8,8 +8,7 @@
     volume_group_size: '10g'
     lv_size: '10g'
     unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
-    disk_size: '{{ unused_disk_subfact.sectors | int *
-                   unused_disk_subfact.sectorsize | int }}'
+    disk_size: '{{ unused_disk_subfact.sectors | int * 512 }}'
   tags:
     - tests::lvm
 

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -8,8 +8,7 @@
     volume_group_size: "5g"
     volume1_size: "4g"
     unused_disk_subfact: "{{ ansible_devices[unused_disks[0]] }}"
-    too_large_size: "{{ (unused_disk_subfact.sectors | int * 1.2) *
-                         unused_disk_subfact.sectorsize | int }}"
+    too_large_size: "{{ (unused_disk_subfact.sectors | int * 1.2) * 512 }}"
   tags:
     - tests::lvm
   tasks:

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -11,10 +11,8 @@
     invalid_size1: xyz GiB
     invalid_size2: none
     unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
-    too_large_size: '{{ unused_disk_subfact.sectors | int * 1.2 *
-                        unused_disk_subfact.sectorsize | int }}'
-    disk_size: '{{ unused_disk_subfact.sectors | int *
-                   unused_disk_subfact.sectorsize | int }}'
+    too_large_size: '{{ unused_disk_subfact.sectors | int * 1.2 * 512 }}'
+    disk_size: '{{ unused_disk_subfact.sectors | int * 512 }}'
   tags:
     - tests::lvm
   tasks:


### PR DESCRIPTION
Device sizes specified in sectors are in general in 512 sectors regardless of the actual device physical sector size. Example of ansible_devices facts for a 4k sector size drive:

...
  "sectors": "41943040",
  "sectorsize": "4096",
  "size": "20.00 GB"
...

Resolves: RHEL-30959
