### PR TITLE
fix: Fix recreate check for formats without labelling support

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -630,7 +630,7 @@ class BlivetVolume(BlivetBase):
             device.original_format._key_file = self._volume.get('encryption_key')
             device.original_format.passphrase = self._volume.get('encryption_password')
             if device.isleaf:
-                self._blivet.populate()
+                self._blivet.devicetree.populate()
 
             if not device.isleaf:
                 device = device.children[0]

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -826,6 +826,9 @@ class BlivetVolume(BlivetBase):
         if ((fmt is None and self._device.format.type is None)
                 or (fmt is not None and self._device.format.type == fmt.type)):
             # format is the same, no need to run reformatting
+            if not hasattr(self._device.format, "label"):
+                # not all formats support labels
+                return
             dev_label = '' if self._device.format.label is None else self._device.format.label
             if dev_label != fmt.label:
                 # ...but the label has changed - schedule modification action

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -111,6 +111,26 @@
     - name: Verify role results
       include_tasks: verify-role-results.yml
 
+    - name: Format the device to LVMPV which doesn't support labels
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            fs_type: lvmpv
+            disks: "{{ unused_disks }}"
+
+    - name: Rerun to check we don't try to relabel preexisitng LVMPV (regression test for RHEL-29874)
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_volumes:
+          - name: test1
+            type: disk
+            fs_type: lvmpv
+            disks: "{{ unused_disks }}"
+
     - name: Clean up
       include_role:
         name: linux-system-roles.storage


### PR DESCRIPTION
Formats like LUKS or LVMPV don't support labels so we need to skip
the label check in BlivetVolume._reformat.

Resolves: RHEL-29874

(The second commit is just partially related to this, I found that issue when testing with LUKS which also doesn't have label support in blivet.)
