### PR TITLE
feat: Stratis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ keys:
 
   This integer specifies the LUKS version to use.
 
+- `encryption_clevis_pin`
+
+  For Stratis pools, the clevis method that should be used to encrypt the created pool.
+  Accepted values are: `tang` and `tpm2`
+
+- `encryption_tang_url`
+
+  When creating a Stratis pool encrypted via NBDE using a tang server,
+  specifies the URL of the server.
+
+- `encryption_tang_thumbprint`
+
+  When creating a Stratis pool encrypted via NBDE using a tang server,
+  specifies the thumbprint of the server.
+
 ### `storage_volumes`
 
 The `storage_volumes` variable is a list of volumes to manage. Each volume has the following

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1330,7 +1330,7 @@ class BlivetMDRaidVolume(BlivetVolume):
 
 
 class BlivetStratisVolume(BlivetVolume):
-    blivet_device_class = devices.StratisFilesystemDevice
+    blivet_device_class = devices.StratisFilesystemDevice if hasattr(devices, "StratisFilesystemDevice") else None
 
     def _update_from_device(self, param_name):
         if param_name == 'fs_type':
@@ -1911,7 +1911,7 @@ class BlivetLVMPool(BlivetPool):
 
 
 class BlivetStratisPool(BlivetPool):
-    blivet_device_class = devices.StratisPoolDevice
+    blivet_device_class = devices.StratisPoolDevice if hasattr(devices, "StratisPoolDevice") else None
 
     def _type_check(self):
         return self._device.type == "stratis pool"

--- a/library/blockdev_info.py
+++ b/library/blockdev_info.py
@@ -85,7 +85,7 @@ def fixup_path(path):
 
 
 def get_block_info(module):
-    buf = module.run_command(["lsblk", "-o", "NAME,FSTYPE,LABEL,UUID,TYPE,SIZE", "-p", "-P", "-a"])[1]
+    buf = module.run_command(["lsblk", "-o", "NAME,FSTYPE,LABEL,UUID,TYPE,SIZE,MOUNTPOINT", "-p", "-P", "-a"])[1]
     info = dict()
     for line in buf.splitlines():
         dev = dict()

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -85,6 +85,9 @@
 - name: Check VDO
   include_tasks: verify-pool-members-vdo.yml
 
+- name: Check Stratis
+  include_tasks: verify-pool-stratis.yml
+
 - name: Clean up test variables
   set_fact:
     _storage_test_expected_pv_type: null

--- a/tests/test-verify-volume-fs.yml
+++ b/tests/test-verify-volume-fs.yml
@@ -1,26 +1,31 @@
 ---
 # type
-- name: Verify fs type
-  assert:
-    that: storage_test_blkinfo.info[storage_test_volume._device].fstype ==
-      storage_test_volume.fs_type or
-      (storage_test_blkinfo.info[storage_test_volume._device].fstype | length
-       == 0 and storage_test_volume.fs_type == "unformatted")
-  when: storage_test_volume.fs_type and _storage_test_volume_present
+- name: Check volume filesystem
+  when: storage_test_volume.type != "stratis"
+  block:
+  - name: Verify fs type
+    assert:
+      that: storage_test_blkinfo.info[storage_test_volume._device].fstype ==
+        storage_test_volume.fs_type or
+        (storage_test_blkinfo.info[storage_test_volume._device].fstype | length
+        == 0 and storage_test_volume.fs_type == "unformatted")
+    when:
+      - storage_test_volume.fs_type
+      - _storage_test_volume_present
 
-# label
-- name: Verify fs label
-  assert:
-    that: storage_test_blkinfo.info[storage_test_volume._device].label ==
-      storage_test_volume.fs_label
-    msg: >-
-      Volume '{{ storage_test_volume.name }}' labels do not match when they
-      should
-      ('{{ storage_test_blkinfo.info[storage_test_volume._device].label }}',
-      '{{ storage_test_volume.fs_label }}')
-  when:
-    - _storage_test_volume_present | bool
-    # label for GFS2 is set manually with the extra `-t` fs_create_options
-    # so we can't verify it here because it was not set with fs_label so
-    # the label from blkinfo doesn't match the expected "empty" fs_label
-    - storage_test_volume.fs_type != "gfs2"
+  # label
+  - name: Verify fs label
+    assert:
+      that: storage_test_blkinfo.info[storage_test_volume._device].label ==
+        storage_test_volume.fs_label
+      msg: >-
+        Volume '{{ storage_test_volume.name }}' labels do not match when they
+        should
+        ('{{ storage_test_blkinfo.info[storage_test_volume._device].label }}',
+        '{{ storage_test_volume.fs_label }}')
+    when:
+      - _storage_test_volume_present | bool
+      # label for GFS2 is set manually with the extra `-t` fs_create_options
+      # so we can't verify it here because it was not set with fs_label so
+      # the label from blkinfo doesn't match the expected "empty" fs_label
+      - storage_test_volume.fs_type != "gfs2"

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -15,20 +15,13 @@
 
 - name: Set some facts
   set_fact:
-    storage_test_mount_device_matches: "{{ ansible_mounts |
-      selectattr('device', 'match', '^' ~ storage_test_device_path ~ '$') |
-      list }}"
-    storage_test_mount_point_matches: "{{ ansible_mounts |
-      selectattr('mount', 'match',
-                 '^' ~ mount_prefix ~ storage_test_volume.mount_point ~ '$') |
-      list if storage_test_volume.mount_point else [] }}"
-    storage_test_mount_expected_match_count: "{{ 1
-      if _storage_test_volume_present and storage_test_volume.mount_point and
-      storage_test_volume.mount_point.startswith('/')
-      else 0 }}"
     storage_test_swap_expected_matches: "{{ 1 if
       _storage_test_volume_present and
       storage_test_volume.fs_type == 'swap' else 0 }}"
+    storage_test_mount_expected_mount_point: "{{
+      '[SWAP]' if storage_test_volume.fs_type == 'swap' else
+      '' if storage_test_volume.mount_point == 'none' else
+      mount_prefix + storage_test_volume.mount_point if storage_test_volume.mount_point else '' }}"
   vars:
     # assumes /opt which is /var/opt in ostree
     mount_prefix: "{{ '/var' if __storage_is_ostree | d(false)
@@ -50,23 +43,12 @@
 #
 - name: Verify the current mount state by device
   assert:
-    that: storage_test_mount_device_matches | length ==
-      storage_test_mount_expected_match_count | int
+    that: storage_test_blkinfo.info[storage_test_volume._device].mountpoint ==
+      storage_test_mount_expected_mount_point
     msg: >-
       Found unexpected mount state for volume
       '{{ storage_test_volume.name }}' device
-  when: _storage_test_volume_present and storage_test_volume.mount_point
-
-#
-# Verify mount directory (state, owner, group, permissions).
-#
-- name: Verify the current mount state by mount point
-  assert:
-    that: storage_test_mount_point_matches | length ==
-      storage_test_mount_expected_match_count | int
-    msg: >-
-      Found unexpected mount state for volume
-      '{{ storage_test_volume.name }}' mount point
+  when: _storage_test_volume_present
 
 - name: Verify mount directory user
   assert:
@@ -105,18 +87,6 @@
         storage_test_volume.mount_mode
 
 #
-# Verify mount fs type.
-#
-- name: Verify the mount fs type
-  assert:
-    that: storage_test_mount_point_matches[0].fstype ==
-      storage_test_volume.fs_type
-    msg: >-
-      Found unexpected mount state for volume
-      '{{ storage_test_volume.name }} fs type
-  when: storage_test_mount_expected_match_count | int == 1
-
-#
 # Verify swap status.
 #
 - name: Get path of test volume device
@@ -145,10 +115,8 @@
 
 - name: Unset facts
   set_fact:
-    storage_test_mount_device_matches: null
-    storage_test_mount_point_matches: null
-    storage_test_mount_expected_match_count: null
     storage_test_swap_expected_matches: null
     storage_test_sys_node: null
     storage_test_swaps: null
     storage_test_found_mount_stat: null
+    storage_test_mount_expected_mount_point: null

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -209,3 +209,40 @@
 
         - name: Verify role results
           include_tasks: verify-role-results.yml
+
+        - name: Setup Tang server on localhost for testing
+          ansible.builtin.include_role:
+            name: fedora.linux_system_roles.nbde_server
+          vars:
+            nbde_server_manage_firewall: true
+            nbde_server_manage_selinux: true
+            nbde_server_port: 7500
+
+        - name: Create encrypted Stratis pool with Clevis/Tang
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks[0] }}"
+                type: stratis
+                encryption: true
+                encryption_password: yabbadabbadoo
+                encryption_clevis_pin: tang
+                encryption_tang_url: localhost:7500
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Clean up
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks[0] }}"
+                type: stratis
+                state: absent
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -1,0 +1,165 @@
+---
+- name: Test stratis pool management
+  hosts: all
+  become: true
+  vars:
+    mount_location: '/opt/test1'
+    mount_location_2: '/opt/test2'
+    volume_group_size: '5g'
+    volume_size: '4g'
+  tags:
+    - tests::stratis
+
+  tasks:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.storage
+
+    - name: Mark tasks to be skipped
+      set_fact:
+        storage_skip_checks:
+          - blivet_available
+          - "{{ (lookup('env',
+                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                ternary('packages_installed', '') }}"
+          - service_facts
+
+    - name: Get unused disks
+      include_tasks: get_unused_disk.yml
+      vars:
+        min_size: "{{ volume_group_size }}"
+        disks_needed: 2
+
+    # stratisd is not started automatically and doesn't support DBus activation
+    # this will be covered by Blivet in the next build
+    - name: Start stratisd service
+      service:
+        name: stratisd
+        state: started
+
+    - name: Create one Stratis pool with one volume
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Repeat the previous invocation to verify idempotence
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Add second filesystem to the pool
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+              - name: test2
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location_2 }}"
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Clean up
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            state: absent
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+                state: absent
+              - name: test2
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location_2 }}"
+                state: absent
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Create encrypted Stratis pool
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            encryption: true
+            encryption_password: yabbadabbadoo
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Repeat the previous invocation to verify idempotence
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            encryption: true
+            encryption_password: yabbadabbadoo
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Clean up
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            type: stratis
+            state: absent
+            volumes:
+              - name: test1
+                size: "{{ volume_size }}"
+                mount_point: "{{ mount_location }}"
+                state: absent
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -163,3 +163,49 @@
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
+
+    # XXX blivet supporting this is not yet released
+    - name: Run test only if blivet supports this functionality
+      when: false
+      block:
+        - name: Create one Stratis pool on one disk
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks[0] }}"
+                type: stratis
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Add the second disk to the pool
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                type: stratis
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Clean up
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: stratis
+                state: absent
+                volumes:
+                  - name: test1
+                    size: "{{ volume_size }}"
+                    mount_point: "{{ mount_location }}"
+                    state: absent
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -110,64 +110,89 @@
     - name: Verify role results
       include_tasks: verify-role-results.yml
 
-    - name: Create encrypted Stratis pool
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            encryption: true
-            encryption_password: yabbadabbadoo
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
+    - name: Gather package facts
+      package_facts:
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+    - name: Set blivet package name
+      set_fact:
+        blivet_pkg_name: "{{ ansible_facts.packages |
+          select('search', 'blivet') | select('search', 'python') | list }}"
 
-    - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            encryption: true
-            encryption_password: yabbadabbadoo
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
+    - name: Set blivet package version
+      set_fact:
+        blivet_pkg_version: "{{
+          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
+          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+    - name: Set distribution version
+      set_fact:
+        is_rhel9: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version == '9' }}"
+        is_rhel10: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version == '10' }}"
+        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
-    - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            state: absent
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
-                state: absent
-
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
-
-    # XXX blivet supporting this is not yet released
     - name: Run test only if blivet supports this functionality
-      when: false
+      when: ((is_fedora and blivet_pkg_version is version("3.10.0-1", ">=")) or
+             (is_rhel10 and blivet_pkg_version is version("3.10.0-1", ">=")) or
+             (is_rhel9 and blivet_pkg_version is version("3.6.0-15", ">=")))
       block:
+        - name: Create encrypted Stratis pool
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: stratis
+                encryption: true
+                encryption_password: yabbadabbadoo
+                volumes:
+                  - name: test1
+                    size: "{{ volume_size }}"
+                    mount_point: "{{ mount_location }}"
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Repeat the previous invocation to verify idempotence
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: stratis
+                encryption: true
+                encryption_password: yabbadabbadoo
+                volumes:
+                  - name: test1
+                    size: "{{ volume_size }}"
+                    mount_point: "{{ mount_location }}"
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Clean up
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: stratis
+                state: absent
+                volumes:
+                  - name: test1
+                    size: "{{ volume_size }}"
+                    mount_point: "{{ mount_location }}"
+                    state: absent
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
         - name: Create one Stratis pool on one disk
           include_role:
             name: linux-system-roles.storage

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -24,92 +24,6 @@
                 ternary('packages_installed', '') }}"
           - service_facts
 
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        disks_needed: 2
-
-    # stratisd is not started automatically and doesn't support DBus activation
-    # this will be covered by Blivet in the next build
-    - name: Start stratisd service
-      service:
-        name: stratisd
-        state: started
-
-    - name: Create one Stratis pool with one volume
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
-
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
-
-    - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
-
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
-
-    - name: Add second filesystem to the pool
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
-              - name: test2
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location_2 }}"
-
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
-
-    - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            type: stratis
-            state: absent
-            volumes:
-              - name: test1
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location }}"
-                state: absent
-              - name: test2
-                size: "{{ volume_size }}"
-                mount_point: "{{ mount_location_2 }}"
-                state: absent
-
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
-
     - name: Gather package facts
       package_facts:
 
@@ -126,6 +40,9 @@
 
     - name: Set distribution version
       set_fact:
+        is_rhel7: "{{ (ansible_facts.distribution == 'CentOS' or
+                    ansible_facts.distribution == 'RedHat') and
+                    ansible_facts.distribution_major_version == '7' }}"
         is_rhel9: "{{ (ansible_facts.distribution == 'CentOS' or
                     ansible_facts.distribution == 'RedHat') and
                     ansible_facts.distribution_major_version == '9' }}"
@@ -134,12 +51,24 @@
                     ansible_facts.distribution_major_version == '10' }}"
         is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
-    - name: Run test only if blivet supports this functionality
-      when: ((is_fedora and blivet_pkg_version is version("3.10.0-1", ">=")) or
-             (is_rhel10 and blivet_pkg_version is version("3.10.0-1", ">=")) or
-             (is_rhel9 and blivet_pkg_version is version("3.6.0-15", ">=")))
+
+    - name: Completely skip this on RHEL/CentOS 7 where Stratis isn't supported
+      when: not is_rhel7
       block:
-        - name: Create encrypted Stratis pool
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            min_size: "{{ volume_group_size }}"
+            disks_needed: 2
+
+        # stratisd is not started automatically and doesn't support DBus activation
+        # this will be covered by Blivet in the next build
+        - name: Start stratisd service
+          service:
+            name: stratisd
+            state: started
+
+        - name: Create one Stratis pool with one volume
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -147,8 +76,6 @@
               - name: foo
                 disks: "{{ unused_disks }}"
                 type: stratis
-                encryption: true
-                encryption_password: yabbadabbadoo
                 volumes:
                   - name: test1
                     size: "{{ volume_size }}"
@@ -165,12 +92,29 @@
               - name: foo
                 disks: "{{ unused_disks }}"
                 type: stratis
-                encryption: true
-                encryption_password: yabbadabbadoo
                 volumes:
                   - name: test1
                     size: "{{ volume_size }}"
                     mount_point: "{{ mount_location }}"
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Add second filesystem to the pool
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                type: stratis
+                volumes:
+                  - name: test1
+                    size: "{{ volume_size }}"
+                    mount_point: "{{ mount_location }}"
+                  - name: test2
+                    size: "{{ volume_size }}"
+                    mount_point: "{{ mount_location_2 }}"
 
         - name: Verify role results
           include_tasks: verify-role-results.yml
@@ -189,85 +133,148 @@
                     size: "{{ volume_size }}"
                     mount_point: "{{ mount_location }}"
                     state: absent
-
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
-
-        - name: Create one Stratis pool on one disk
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks[0] }}"
-                type: stratis
-
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
-
-        - name: Add the second disk to the pool
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-                type: stratis
-
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
-
-        - name: Clean up
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks }}"
-                type: stratis
-                state: absent
-                volumes:
-                  - name: test1
+                  - name: test2
                     size: "{{ volume_size }}"
-                    mount_point: "{{ mount_location }}"
+                    mount_point: "{{ mount_location_2 }}"
                     state: absent
 
         - name: Verify role results
           include_tasks: verify-role-results.yml
 
-        - name: Setup Tang server on localhost for testing
-          ansible.builtin.include_role:
-            name: fedora.linux_system_roles.nbde_server
-          vars:
-            nbde_server_manage_firewall: true
-            nbde_server_manage_selinux: true
-            nbde_server_port: 7500
+        - name: Run test only if blivet supports this functionality
+          when: ((is_fedora and blivet_pkg_version is version("3.10.0-1", ">=")) or
+                (is_rhel10 and blivet_pkg_version is version("3.10.0-1", ">=")) or
+                (is_rhel9 and blivet_pkg_version is version("3.6.0-15", ">=")))
+          block:
+            - name: Create encrypted Stratis pool
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    type: stratis
+                    encryption: true
+                    encryption_password: yabbadabbadoo
+                    volumes:
+                      - name: test1
+                        size: "{{ volume_size }}"
+                        mount_point: "{{ mount_location }}"
 
-        - name: Create encrypted Stratis pool with Clevis/Tang
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks[0] }}"
-                type: stratis
-                encryption: true
-                encryption_password: yabbadabbadoo
-                encryption_clevis_pin: tang
-                encryption_tang_url: localhost:7500
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
 
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
+            - name: Repeat the previous invocation to verify idempotence
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    type: stratis
+                    encryption: true
+                    encryption_password: yabbadabbadoo
+                    volumes:
+                      - name: test1
+                        size: "{{ volume_size }}"
+                        mount_point: "{{ mount_location }}"
 
-        - name: Clean up
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks[0] }}"
-                type: stratis
-                state: absent
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
 
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
+            - name: Clean up
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    type: stratis
+                    state: absent
+                    volumes:
+                      - name: test1
+                        size: "{{ volume_size }}"
+                        mount_point: "{{ mount_location }}"
+                        state: absent
+
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
+
+            - name: Create one Stratis pool on one disk
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks[0] }}"
+                    type: stratis
+
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
+
+            - name: Add the second disk to the pool
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                    type: stratis
+
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
+
+            - name: Clean up
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    type: stratis
+                    state: absent
+                    volumes:
+                      - name: test1
+                        size: "{{ volume_size }}"
+                        mount_point: "{{ mount_location }}"
+                        state: absent
+
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
+
+            - name: Setup Tang server on localhost for testing
+              ansible.builtin.include_role:
+                name: fedora.linux_system_roles.nbde_server
+              vars:
+                nbde_server_manage_firewall: true
+                nbde_server_manage_selinux: true
+                nbde_server_port: 7500
+
+            - name: Create encrypted Stratis pool with Clevis/Tang
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks[0] }}"
+                    type: stratis
+                    encryption: true
+                    encryption_password: yabbadabbadoo
+                    encryption_clevis_pin: tang
+                    encryption_tang_url: localhost:7500
+
+            - name: Verify role results
+              include_tasks: verify-role-results.yml
+
+            - name: Clean up
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks[0] }}"
+                    type: stratis
+                    state: absent
+
+            - name: Verify role results
+              include_tasks: verify-role-results.yml

--- a/tests/verify-pool-stratis.yml
+++ b/tests/verify-pool-stratis.yml
@@ -26,12 +26,25 @@
     - name: Verify that encryption is correctly set
       assert:
         that: storage_test_pool.name in
-          _stratis_pool_info[0]['blockdevs']['datadevs'][0]['key_description']
+          _stratis_pool_info.pools[0]['blockdevs']['datadevs'][0]['key_description']
         msg: >-
           Stratis pool '{{ storage_test_pool.name }}' is not encrypted
       when:
         - storage_test_pool.state == 'present'
         - storage_test_pool.encryption
+
+    - name: Verify that Clevis/Tang encryption is correctly set
+      assert:
+        that:
+          _stratis_pool_info.pools[0]['blockdevs']['datadevs'][0]['clevis_pin'] == 'tang' and
+          _stratis_pool_info.pools[0]['blockdevs']['datadevs'][0]['clevis_config']['url'] ==
+          storage_test_pool.encryption_tang_url
+        msg: >-
+          Stratis pool '{{ storage_test_pool.name }}' Clevis is not correctly configured
+      when:
+        - storage_test_pool.state == 'present'
+        - storage_test_pool.encryption
+        - storage_test_pool.encryption_clevis_pin == 'tang'
 
 - name: Reset variable used by test
   set_fact:

--- a/tests/verify-pool-stratis.yml
+++ b/tests/verify-pool-stratis.yml
@@ -1,0 +1,38 @@
+---
+# Only when pool is stratis
+- name: Check Stratis options
+  when: storage_test_pool.type == 'stratis'
+  block:
+    - name: Run 'stratis report'
+      command: stratis report
+      register: storage_test_stratis_report
+      changed_when: false
+
+    - name: Get information about Stratis
+      set_fact:
+        _stratis_pool_info: "{{ storage_test_stratis_report.stdout | from_json }}"
+
+    - name: Verify that the pools was created
+      assert:
+        that: _stratis_pool_info.pools | length == 1 and
+              _stratis_pool_info.pools[0].name == storage_test_pool.name
+        msg: >-
+          Stratis pool '{{ storage_test_pool.name }}' not found
+      when: storage_test_pool.state == 'present'
+
+    # Stratis internally uses LUKS so verify-pool-member-encryption will also
+    # cover this we just need to make sure this is encrypted Stratis pool
+    # and not Stratis on top of "normal LUKS
+    - name: Verify that encryption is correctly set
+      assert:
+        that: storage_test_pool.name in
+          _stratis_pool_info[0]['blockdevs']['datadevs'][0]['key_description']
+        msg: >-
+          Stratis pool '{{ storage_test_pool.name }}' is not encrypted
+      when:
+        - storage_test_pool.state == 'present'
+        - storage_test_pool.encryption
+
+- name: Reset variable used by test
+  set_fact:
+    storage_test_stratis_report: null

--- a/vars/AlmaLinux_8.yml
+++ b/vars/AlmaLinux_8.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/AlmaLinux_9.yml
+++ b/vars/AlmaLinux_9.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -6,6 +6,8 @@ blivet_package_list:
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap
+  - stratisd
+  - stratis-cli
 _storage_copr_packages:
   - repository: "rhawalsh/dm-vdo"
     packages:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/Rocky_8.yml
+++ b/vars/Rocky_8.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli

--- a/vars/Rocky_9.yml
+++ b/vars/Rocky_9.yml
@@ -9,3 +9,5 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
+  - stratisd
+  - stratis-cli


### PR DESCRIPTION
Support for creating and managing Stratis pools and volumes. For now this is just a draft because we need a new version of Blivet to be available for the full support. This includes support for creating Stratis pools and filesystems and adding new block devices to an existing Stratis pool (removing block devices is not supported by Stratis). Encrypted Stratis pools can be created with Clevis/Tang or TPM support.

Resolves: RHEL-31854
