### PR TITLE
fix: Get same sector size disks for multi device LVM tests

### DIFF
--- a/tests/get_unused_disk.yml
+++ b/tests/get_unused_disk.yml
@@ -19,6 +19,7 @@
     max_size: "{{ max_size | d(omit) }}"
     max_return: "{{ max_return | d(omit) }}"
     with_interface: "{{ storage_test_use_interface | d(omit) }}"
+    match_sector_size: "{{ match_sector_size | d(omit) }}"
   register: unused_disks_return
 
 - name: Set unused_disks if necessary

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -31,7 +31,7 @@
       include_tasks: get_unused_disk.yml
       vars:
         min_size: "{{ volume_size }}"
-        max_return: 2
+        max_return: 1
 
     - name: Create an LVM partition with the default file system type
       include_role:

--- a/tests/tests_create_lvm_cache_then_remove.yml
+++ b/tests/tests_create_lvm_cache_then_remove.yml
@@ -57,6 +57,7 @@
         min_size: "{{ volume_group_size }}"
         max_return: 2
         disks_needed: 2
+        match_sector_size: true
 
     - name: Create a cached LVM logical volume under volume group 'foo'
       include_role:

--- a/tests/tests_create_thinp_then_remove.yml
+++ b/tests/tests_create_thinp_then_remove.yml
@@ -23,6 +23,7 @@
       include_tasks: get_unused_disk.yml
       vars:
         max_return: 3
+        match_sector_size: true
 
     - name: Create a thinpool device
       include_role:

--- a/tests/tests_fatals_cache_volume.yml
+++ b/tests/tests_fatals_cache_volume.yml
@@ -29,6 +29,7 @@
       vars:
         max_return: 2
         disks_needed: 2
+        match_sector_size: true
 
     - name: Verify that creating a cached partition volume fails
       include_tasks: verify-role-failed.yml

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -29,6 +29,7 @@
         min_size: "{{ volume_group_size }}"
         max_return: 2
         disks_needed: 2
+        match_sector_size: true
 
     - name: >-
         Create a logical volume spanning two physical volumes that changes its

--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -59,6 +59,7 @@
           vars:
             min_size: "{{ volume_group_size }}"
             disks_needed: 3
+            match_sector_size: true
 
         - name: Create volume group 'foo' with 3 PVs
           include_role:

--- a/tests/unit/test_unused_disk.py
+++ b/tests/unit/test_unused_disk.py
@@ -10,9 +10,9 @@ import os
 blkid_data_pttype = [('/dev/sdx', '/dev/sdx: PTTYPE=\"dos\"'),
                      ('/dev/sdy', '/dev/sdy: PTTYPE=\"test\"')]
 
-blkid_data = [('/dev/sdx', 'UUID=\"hello-1234-56789\" TYPE=\"crypto_LUKS\"'),
-              ('/dev/sdy', 'UUID=\"this-1s-a-t3st-f0r-ansible\" VERSION=\"LVM2 001\" TYPE=\"LVM2_member\" USAGE=\"raid\"'),
-              ('/dev/sdz', 'LABEL=\"/data\" UUID=\"a12bcdef-345g-67h8-90i1-234j56789k10\" VERSION=\"1.0\" TYPE=\"ext4\" USAGE=\"filesystem\"')]
+blkid_data = [('/dev/sdx', 'UUID=\"hello-1234-56789\" TYPE=\"crypto_LUKS\" LOG-SEC=\"512\"'),
+              ('/dev/sdy', 'UUID=\"this-1s-a-t3st-f0r-ansible\" VERSION=\"LVM2 001\" TYPE=\"LVM2_member\" USAGE=\"raid\" LOG-SEC=\"512\"'),
+              ('/dev/sdz', 'LABEL=\"/data\" UUID=\"a12bcdef-345g-67h8-90i1-234j56789k10\" VERSION=\"1.0\" TYPE=\"ext4\" USAGE=\"filesystem\" LOG-SEC=\"512\"')]
 
 holders_data_none = [('/dev/sdx', ''),
                      ('/dev/dm-99', '')]


### PR DESCRIPTION
LVM doesn't allow creating VGs on top of disks with different sector sizes and when running our tests on machine with disks with both 512 and 4096 sectors LVM tests that use multiple disks can fail. This change adds a new option to the find_unused_disks module to request disks with the same sector sizes and uses this new option in the LVM tests that use multiple disks.

Issue Tracker Tickets (Jira or BZ if any): RHEL-25994
