### PR TITLE
fix: Fix expected error message in tests_misc.yml

### DIFF
--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -68,8 +68,9 @@
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
-          Failed to commit changes to disk.*FSError.*format failed:
-          1.*/dev/mapper/foo-test1
+          Failed to commit changes to disk.*(FSError.*format failed:
+          1.*/dev/mapper/foo-test1|
+          Process reported exit code 1: mke2fs: invalid block size - 512)
         __storage_failed_msg: >-
           Unexpected behavior when creating ext4 filesystem with invalid
           parameter


### PR DESCRIPTION
Different versions of blivet return a different error message when trying to create a filesystem with invalid parameters.

On Fedora 39 and older:
"Failed to commit changes to disk: (FSError('format failed: 1'), '/dev/mapper/foo-test1')"

On Fedora 40 and newer:
"Failed to commit changes to disk: Process reported exit code 1: mke2fs: invalid block size - 512\n"