### PR TITLE
test: lsblk can return LOG_SEC or LOG-SEC

### DIFF
--- a/library/find_unused_disk.py
+++ b/library/find_unused_disk.py
@@ -149,9 +149,9 @@ def get_disks(module):
         if not line:
             continue
 
-        m = re.search(r'NAME="(?P<path>[^"]*)" TYPE="(?P<type>[^"]*)" SIZE="(?P<size>\d+)" FSTYPE="(?P<fstype>[^"]*)" LOG-SEC="(?P<ssize>\d+)"', line)
+        m = re.search(r'NAME="(?P<path>[^"]*)" TYPE="(?P<type>[^"]*)" SIZE="(?P<size>\d+)" FSTYPE="(?P<fstype>[^"]*)" LOG[_-]SEC="(?P<ssize>\d+)"', line)
         if m is None:
-            module.log(line)
+            module.log("Line did not match: " + line)
             continue
 
         if m.group('type') != "disk":

--- a/tests/get_unused_disk.yml
+++ b/tests/get_unused_disk.yml
@@ -22,6 +22,15 @@
     match_sector_size: "{{ match_sector_size | d(omit) }}"
   register: unused_disks_return
 
+- name: Debug why there are no unused disks
+  shell: |
+    set -x
+    exec 1>&2
+    lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE,LOG-SEC
+    journalctl -ex
+  changed_when: false
+  when: "'Unable to find unused disk' in unused_disks_return.disks"
+
 - name: Set unused_disks if necessary
   set_fact:
     unused_disks: "{{ unused_disks_return.disks }}"


### PR DESCRIPTION
get_unused_disk is broken on some systems because `lsblk ... LOG-SEC` can
return `LOG_SEC` with an underscore instead of the requested
`LOG-SEC` with a dash.
