### PR TITLE
test: lvm pool members test fix

### DIFF
--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -6,7 +6,7 @@
     storage_safe_mode: false
     storage_use_partitions: true
     volume_group_size: '10g'
-    volume_size: '20m'
+    volume_size: '300m'
   tags:
     - tests::lvm
 


### PR DESCRIPTION
tests_lvm_pool_members started to fail. It tried to create a device with a requested size (20m) that was less than minimal allowed size (300m) for that type of volume. Role automatically resized the device to allowed size. That lead to discrepancy in actual and expected size values.

Increasing the requested device size to be same or larger than minimal fixes the issue.