### PR TITLE
fix: check mode should not give an error

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -2396,7 +2396,7 @@ def run_module():
 
     module.params.update(updated_params)
 
-    if not BLIVET_PACKAGE:
+    if not BLIVET_PACKAGE and not module.check_mode:
         module.fail_json(msg="Failed to import the blivet or blivet3 Python modules",
                          exception=inspect.cleandoc("""
                          blivet3 exception:


### PR DESCRIPTION
Cause: The blivet module was not looking for the check_mode flag before
reporting an error when the supporting modules could not be loaded.

Consequence: The storage role would give an error in check mode in the
"Get required packages" task.

Fix: See if the role is running in check mode, and do not report an
error if the underlying modules cannot be loaded.  This is expected.

Result: The storage role does not print an error when running in
check mode.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
