### PR TITLE
feat: write storage role fingerprint to /etc/fstab

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -102,6 +102,24 @@
         - storage_udevadm_trigger | d(false)
         - blivet_output is changed
 
+    - name: Check if /etc/fstab is present
+      stat:
+        path: /etc/fstab
+      register: __storage_fstab
+
+    - name: Add fingerprint to /etc/fstab if present
+      lineinfile:
+        insertbefore: "^#"
+        firstmatch: true
+        line: "{{ __str }}"
+        regexp: "{{ __str }}"
+        path: /etc/fstab
+        state: present
+      vars:
+        __str: "# system_role:storage"
+      when:
+        - __storage_fstab.stat.exists
+        - blivet_output is changed
   rescue:
     - name: Failed message
       fail:

--- a/tests/test-verify-volume-fstab.yml
+++ b/tests/test-verify-volume-fstab.yml
@@ -68,6 +68,12 @@
     - "'mount_options' in storage_test_volume"
     - "'mount_point' in storage_test_volume"
 
+- name: Verify fingerprint
+  assert:
+    that: __fingerprint in storage_test_fstab.stdout
+  vars:
+    __fingerprint: "system_role:storage"
+
 - name: Clean up variables
   set_fact:
     storage_test_fstab_id_matches: null


### PR DESCRIPTION
Feature: Write storage role fingerprint to /etc/fstab

Reason: This will allow us to track usage of the storage role
on managed nodes.

Result: Storage role usage on managed nodes can be tracked.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
