### PR TITLE
fix: Add libblockdev s390 and FS plugins to blivet dependencies list

### DIFF
--- a/vars/AlmaLinux_10.yml
+++ b/vars/AlmaLinux_10.yml
@@ -9,5 +9,8 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
 # vdo not yet available on el10
 #  - vdo

--- a/vars/AlmaLinux_10.yml
+++ b/vars/AlmaLinux_10.yml
@@ -3,6 +3,7 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-crypto
   - libblockdev-dm
+  - libblockdev-fs
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap

--- a/vars/AlmaLinux_8.yml
+++ b/vars/AlmaLinux_8.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/AlmaLinux_9.yml
+++ b/vars/AlmaLinux_9.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -9,5 +9,8 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
 # vdo not yet available on el10
 #  - vdo

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -3,6 +3,7 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-crypto
   - libblockdev-dm
+  - libblockdev-fs
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -7,6 +7,9 @@ blivet_package_list:
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
 # additional options for mkfs when creating a disk volume (whole disk fs)
 __storage_blivet_diskvolume_mkfs_option_map:
   ext2: '-F'

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -3,6 +3,7 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-crypto
   - libblockdev-dm
+  - libblockdev-fs
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -8,6 +8,9 @@ blivet_package_list:
   - libblockdev-swap
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
 _storage_copr_packages:
   - repository: "rhawalsh/dm-vdo"
     packages:

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -9,5 +9,8 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
 # vdo not yet available on el10
 #  - vdo

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -3,6 +3,7 @@ blivet_package_list:
   - python3-blivet
   - libblockdev-crypto
   - libblockdev-dm
+  - libblockdev-fs
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -7,6 +7,9 @@ blivet_package_list:
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
 # additional options for mkfs when creating a disk volume (whole disk fs)
 __storage_blivet_diskvolume_mkfs_option_map:
   ext2: '-F'

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/Rocky_8.yml
+++ b/vars/Rocky_8.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"

--- a/vars/Rocky_9.yml
+++ b/vars/Rocky_9.yml
@@ -11,3 +11,6 @@ blivet_package_list:
   - xfsprogs
   - stratisd
   - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"


### PR DESCRIPTION
The s390 plugin is needed everywhere but on s390 only (it is not available on other architectures). The filesystem plugin is needed only on Fedora and CentOS/RHEL 10.
