### PR TITLE
chore: Add support for Oracle Linux 9.x

### DIFF
--- a/vars/OracleLinux_9.yml
+++ b/vars/OracleLinux_9.yml
@@ -1,0 +1,16 @@
+---
+blivet_package_list:
+  - python3-blivet
+  - libblockdev-crypto
+  - libblockdev-dm
+  - libblockdev-lvm
+  - libblockdev-mdraid
+  - libblockdev-swap
+  - vdo
+  - kmod-kvdo
+  - xfsprogs
+  - stratisd
+  - stratis-cli
+  # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
+  # else, it is already brought in as dependency of blivet so it's just no-op here
+  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"


### PR DESCRIPTION
Enhancement: adding support for Oracle Linux 9.x

Reason: current variable files do not return a match on this OS flavor/version

Result: copied package list from RedHat_9 and verified behavior for storage_pools (lvm) backed with virtual scsi disks

Issue Tracker Tickets (Jira or BZ if any): #444 
