### PR TITLE
fix: architecture is now a required fact

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 # ansible_facts required by the role
 __storage_required_facts:
+  - architecture
   - distribution
   - distribution_major_version
   - distribution_version


### PR DESCRIPTION
Due to https://github.com/linux-system-roles/storage/pull/467
architecture is now a required Ansible fact

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
