### PR TITLE
test: use pvcreate with a timeout and verbose logging

### DIFF
--- a/tests/tests_lvm_pool_pv_grow.yml
+++ b/tests/tests_lvm_pool_pv_grow.yml
@@ -33,7 +33,9 @@
         min_size: "10g"
 
     - name: Create PV with a space to grow
-      command: "pvcreate --setphysicalvolumesize {{ pv_size }} /dev/{{ unused_disks[0] }}"
+      command: >-
+        timeout 30s pvcreate -vvv -y --setphysicalvolumesize
+        {{ pv_size | quote }} /dev/{{ unused_disks[0] | quote }}
       register: pvcreate_output
       changed_when: pvcreate_output.rc != 0
 


### PR DESCRIPTION
the pvcreate call gives us problems, and different problems on different
platforms.  Use `timeout 30s` to avoid hangs when it tries
to read from stdin.  Use verbose `-vvv` to figure out why it
hangs/fails.  Use `-y` to make it not ask questions and continue
anyway.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
