### PR TITLE
fix: add stratis to list of packages for ostree

### DIFF
--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,1 +1,3 @@
 python3-blivet
+stratisd
+stratis-cli

--- a/.ostree/packages-runtime-CentOS-8.txt
+++ b/.ostree/packages-runtime-CentOS-8.txt
@@ -1,3 +1,5 @@
 kmod-kvdo
 python3-blivet
 vdo
+stratisd
+stratis-cli

--- a/.ostree/packages-runtime-CentOS-9.txt
+++ b/.ostree/packages-runtime-CentOS-9.txt
@@ -1,3 +1,5 @@
 kmod-kvdo
 python3-blivet
 vdo
+stratisd
+stratis-cli

--- a/.ostree/packages-runtime-Fedora.txt
+++ b/.ostree/packages-runtime-Fedora.txt
@@ -1,1 +1,3 @@
 python3-blivet
+stratisd
+stratis-cli

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,1 +1,3 @@
 python3-blivet
+stratisd
+stratis-cli

--- a/.ostree/packages-runtime-RedHat-8.txt
+++ b/.ostree/packages-runtime-RedHat-8.txt
@@ -1,3 +1,5 @@
 kmod-kvdo
 python3-blivet
 vdo
+stratisd
+stratis-cli

--- a/.ostree/packages-runtime-RedHat-9.txt
+++ b/.ostree/packages-runtime-RedHat-9.txt
@@ -1,3 +1,5 @@
 kmod-kvdo
 python3-blivet
 vdo
+stratisd
+stratis-cli

--- a/.ostree/packages-testing-CentOS-10.txt
+++ b/.ostree/packages-testing-CentOS-10.txt
@@ -1,1 +1,5 @@
 util-linux-core
+clevis
+clevis-luks
+tpm2-tools
+jq

--- a/.ostree/packages-testing-CentOS-8.txt
+++ b/.ostree/packages-testing-CentOS-8.txt
@@ -1,1 +1,5 @@
 util-linux
+clevis
+clevis-luks
+tpm2-tools
+jq

--- a/.ostree/packages-testing-CentOS-9.txt
+++ b/.ostree/packages-testing-CentOS-9.txt
@@ -1,1 +1,5 @@
 util-linux-core
+clevis
+clevis-luks
+tpm2-tools
+jq

--- a/.ostree/packages-testing-Fedora.txt
+++ b/.ostree/packages-testing-Fedora.txt
@@ -1,2 +1,6 @@
 nilfs-utils
 util-linux-core
+clevis
+clevis-luks
+tpm2-tools
+jq

--- a/.ostree/packages-testing-RedHat-10.txt
+++ b/.ostree/packages-testing-RedHat-10.txt
@@ -1,1 +1,5 @@
 util-linux-core
+clevis
+clevis-luks
+tpm2-tools
+jq

--- a/.ostree/packages-testing-RedHat-8.txt
+++ b/.ostree/packages-testing-RedHat-8.txt
@@ -1,1 +1,5 @@
 util-linux
+clevis
+clevis-luks
+tpm2-tools
+jq

--- a/.ostree/packages-testing-RedHat-9.txt
+++ b/.ostree/packages-testing-RedHat-9.txt
@@ -1,1 +1,5 @@
+clevis
+clevis-luks
+tpm2-tools
+jq
 util-linux-core

--- a/.ostree/roles-testing.txt
+++ b/.ostree/roles-testing.txt
@@ -1,0 +1,1 @@
+nbde_server


### PR DESCRIPTION
stratis testing needs the nbde_server role and several clevis
and tpm2 utilities.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
