### PR TITLE
fix: Skip Stratis tests on RHEL 8 and document Stratis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ As of now, the role supports managing file systems and mount entries on
 
 - disks
 - LVM volume groups
-- Stratis pools
+- Stratis pools (with Stratis v3 and newer)
 
 Encryption (using LUKS) and RAID (using MD) is also supported. Support
 for managing pre-existing devices is limited, but new LVM volumes and

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -40,8 +40,9 @@
 
     - name: Set distribution version
       set_fact:
-        is_rhel7: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    ansible_facts.distribution_major_version == '7' }}"
+        is_rhel78: "{{ (ansible_facts['os_family'] == 'RedHat') and
+                    (ansible_facts.distribution_major_version == '7' or
+                     ansible_facts.distribution_major_version == '8') }}"
         is_rhel9: "{{ (ansible_facts['os_family'] == 'RedHat') and
                     ansible_facts.distribution_major_version == '9' }}"
         is_rhel10: "{{ (ansible_facts['os_family'] == 'RedHat') and
@@ -49,8 +50,8 @@
         is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
 
-    - name: Completely skip this on RHEL/CentOS 7 where Stratis isn't supported
-      when: not is_rhel7
+    - name: Completely skip this on RHEL/CentOS 7 and 8 where Stratis isn't supported by blivet
+      when: not is_rhel78
       block:
         - name: Get unused disks
           include_tasks: get_unused_disk.yml


### PR DESCRIPTION
Unfortunately Blivet supports only the Stratis v3 API so we cannot support Stratis on RHEL/CentOS 8 where only Stratis v2 is available.