### PR TITLE
fix: VDO tests and packages fixes for Fedora and RHEL 10

### DIFF
--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -40,19 +40,30 @@
           ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
           '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
 
+    - name: Set libblockdev package version
+      set_fact:
+        libblockdev_pkg_version: "{{
+          ansible_facts.packages['libblockdev'][0]['version'] +
+          '-' + ansible_facts.packages['libblockdev'][0]['release'] }}"
+
     - name: Check if kvdo is loadable
-      shell: |
-        set -euo pipefail
-        modprobe --dry-run kvdo
+      command: modprobe --dry-run kvdo
       ignore_errors: true  # noqa ignore-errors
       changed_when: false
       register: __storage_kvdo_loadable
 
+    - name: Check if dm-vdo is loadable
+      command: modprobe --dry-run dm-vdo
+      ignore_errors: true  # noqa ignore-errors
+      changed_when: false
+      register: __storage_dmvdo_loadable
+
     - name: Run tests if VDO is available
       when:
         - blivet_pkg_version is version("3.2.2-10", ">=")
-        - ansible_facts["distribution"] != "Fedora"
-        - __storage_kvdo_loadable is success
+        - ansible_facts["distribution"] != "Fedora" or
+          libblockdev_pkg_version is version("3.1.1-2", ">=")
+        - __storage_kvdo_loadable is success or __storage_dmvdo_loadable is success
       block:
         - name: Get unused disks
           include_tasks: get_unused_disk.yml

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -12,10 +12,6 @@ blivet_package_list:
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
-_storage_copr_packages:
-  - repository: "rhawalsh/dm-vdo"
-    packages:
-      - vdo
-      - kmod-vdo
+  - vdo
 _storage_copr_support_packages:
   - dnf-plugins-core

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -13,5 +13,4 @@ blivet_package_list:
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
-# vdo not yet available on el10
-#  - vdo
+  - vdo


### PR DESCRIPTION
The VDO kernel module is now part of upstream kernel and renamed from *kvdo* to *dm-vdo*. The *vdo* package with userspace tools is now available on RHEL/CentOS 10 and Fedora in standard repositories, no need to enable the Copr repository.
