### PR TITLE
test: skip fingerprint if fstab is not written

### DIFF
--- a/tests/test-verify-volume-fstab.yml
+++ b/tests/test-verify-volume-fstab.yml
@@ -73,6 +73,7 @@
     that: __fingerprint in storage_test_fstab.stdout
   vars:
     __fingerprint: "system_role:storage"
+  when: not storage_test_skip_fingerprint | d(false)
 
 - name: Clean up variables
   set_fact:

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -6,6 +6,7 @@
     storage_safe_mode: false
     storage_use_partitions: true
     mount_location1: '/opt/test1'
+    storage_test_skip_fingerprint: true
   tags:
     - tests::lvm
 


### PR DESCRIPTION
Some tests do not cause the role to touch /etc/fstab, so skip the
fingerprint check.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
