### PR TITLE
fix: Fix PV grow_to_fill feature 

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1853,8 +1853,8 @@ class BlivetLVMPool(BlivetPool):
                 pv.format.update_size_info()  # set pv to be resizable
 
                 if pv.format.resizable:
-                    pv.grow_to_fill = True
-                    ac = ActionResizeFormat(pv, self._device.size)
+                    pv.format.grow_to_fill = True
+                    ac = ActionResizeFormat(pv, pv.size)
                     self._blivet.devicetree.actions.add(ac)
                 else:
                     log.warning("cannot grow/resize PV '%s', format is not resizable", pv.name)

--- a/tests/scripts/does_library_support.py
+++ b/tests/scripts/does_library_support.py
@@ -59,4 +59,5 @@ if __name__ == "__main__":
         print("Usage: python %s <parameter>" % sys.argv[0])
         sys.exit(-1)
 
-    print(is_supported(sys.argv[1]))
+    ret = is_supported(sys.argv[1])
+    sys.exit(0) if ret else sys.exit(1)

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -78,6 +78,7 @@
     executable: "{{ ansible_python.executable }}"
   register: grow_supported
   changed_when: false
+  failed_when: grow_supported.rc not in [0, 1]
 
 - name: Verify that PVs fill the whole devices when they should
   include_tasks: verify-pool-member-pvsize.yml
@@ -85,7 +86,7 @@
   loop_control:
     loop_var: st_pool_pv
   when:
-    - grow_supported.stdout | trim == 'True'
+    - grow_supported.rc == 0
     - storage_test_pool.type == "lvm"
     - storage_test_pool.grow_to_fill | bool
 

--- a/tests/tests_lvm_pool_pv_grow.yml
+++ b/tests/tests_lvm_pool_pv_grow.yml
@@ -4,11 +4,7 @@
   become: true
   vars:
     storage_safe_mode: false
-    mount_location1: '/opt/test1'
-    mount_location2: '/opt/test2'
     pv_size: '8g'
-    volume1_size: '2g'
-    volume2_size: '3g'
   tags:
     - tests::lvm
 
@@ -57,11 +53,7 @@
             state: present
             volumes:
               - name: test1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: test2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
+                size: 100%
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
@@ -77,11 +69,7 @@
             state: present
             volumes:
               - name: test1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: test2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
+                size: 100%
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
@@ -96,7 +84,6 @@
             state: "absent"
             volumes:
               - name: test1
-              - name: test2
 
     - name: Verify role results
       include_tasks: verify-role-results.yml

--- a/tests/verify-pool-member-pvsize.yml
+++ b/tests/verify-pool-member-pvsize.yml
@@ -4,21 +4,28 @@
   register: actual_pv_size
   changed_when: false
 
+- name: Get PE start for the PV
+  command: "pvs --noheadings --nosuffix --units b -o PESTART {{ st_pool_pv }}"
+  register: pv_pe_start
+  changed_when: false
+
 - name: Convert blkinfo size to bytes
   bsize:
     size: "{{ storage_test_blkinfo.info[st_pool_pv]['size'] }}"
   register: dev_size
 
+# the difference should be at maximum 1 PE + PE start
 - name: Verify each PV size
   assert:
-    that: (dev_size.bytes - actual_pv_size.stdout | int) |
-      abs / actual_pv_size.stdout | int < 0.04
+    that: (dev_size.bytes - actual_pv_size.stdout | int) <=
+          (4194304 + pv_pe_start.stdout | int)
     msg: >-
-      PV resize failure; size difference too big
+      Unexpected difference between PV size and block device size:
       (device size: {{ dev_size.bytes }})
       (actual PV size: {{ actual_pv_size.stdout }})
 
 - name: Clean up test variables
   set_fact:
     actual_pv_size: null
+    pv_pe_start: null
     dev_size: null


### PR DESCRIPTION

The issues with the PV grow feature: the code doesn't correctly set the `grow_to_fill` property for blivet and uses VG size instead of the underlying block device size for the target size for the resize action. I've fixed these and adjusted tests to actually check the PV size after resize without allowing for difference bigger than 4 MiB (one physical extent for metadata and padding) and to cover the customer issue (resizing both the PV format and LV).