### PR TITLE
fix: ensure ostree has libblockdev and libblockdev-loop

### DIFF
--- a/.ostree/packages-runtime.txt
+++ b/.ostree/packages-runtime.txt
@@ -1,8 +1,10 @@
 cryptsetup
 e2fsprogs
 kpartx
+libblockdev
 libblockdev-crypto
 libblockdev-dm
+libblockdev-loop
 libblockdev-lvm
 libblockdev-mdraid
 libblockdev-swap


### PR DESCRIPTION
The packages libblockdev and libblockdev-loop are required to
build ostree images.
