### PR TITLE
tests: Fix more cleanups; ci: Attach batch.txt and batch.report on failures

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -114,7 +114,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
-          path: tests/*.log
+          path: |
+            tests/*.log
+            batch.txt
+            batch.report
           retention-days: 30
 
       - name: Show test log failures

--- a/tests/tests_lvm_pool_pv_grow.yml
+++ b/tests/tests_lvm_pool_pv_grow.yml
@@ -9,81 +9,84 @@
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+    - name: Test
+      block:
+        - name: Run the role
+          include_role:
+            name: linux-system-roles.storage
 
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - service_facts
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
+        - name: Mark tasks to be skipped
+          set_fact:
+            storage_skip_checks:
+              - blivet_available
+              - service_facts
+              - "{{ (lookup('env',
+                            'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
+                    ternary('packages_installed', '') }}"
 
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
-        min_size: "10g"
+        - name: Get unused disks
+          include_tasks: get_unused_disk.yml
+          vars:
+            max_return: 1
+            min_size: "10g"
 
-    - name: Create PV with a space to grow
-      command: >-
-        timeout 30s pvcreate -vvv -y --setphysicalvolumesize
-        {{ pv_size | quote }} /dev/{{ unused_disks[0] | quote }}
-      register: pvcreate_output
-      changed_when: pvcreate_output.rc != 0
+        - name: Create PV with a space to grow
+          command: >-
+            timeout 30s pvcreate -vvv -y --setphysicalvolumesize
+            {{ pv_size | quote }} /dev/{{ unused_disks[0] | quote }}
+          register: pvcreate_output
+          changed_when: pvcreate_output.rc != 0
 
-      # VG has to be present, the role otherwise automatically reformats empty PV,
-      # taking all available space
-    - name: Create VG
-      command: "vgcreate foo /dev/{{ unused_disks[0] }}"
-      register: vgcreate_output
-      changed_when: vgcreate_output.rc != 0
+          # VG has to be present, the role otherwise automatically reformats empty PV,
+          # taking all available space
+        - name: Create VG
+          command: "vgcreate foo /dev/{{ unused_disks[0] }}"
+          register: vgcreate_output
+          changed_when: vgcreate_output.rc != 0
 
-    - name: Create LVM
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            grow_to_fill: true
-            state: present
-            volumes:
-              - name: test1
-                size: 100%
+        - name: Create LVM
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                grow_to_fill: true
+                state: present
+                volumes:
+                  - name: test1
+                    size: 100%
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Rerun the task to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            grow_to_fill: true
-            state: present
-            volumes:
-              - name: test1
-                size: 100%
+        - name: Rerun the task to verify idempotence
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                grow_to_fill: true
+                state: present
+                volumes:
+                  - name: test1
+                    size: 100%
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Remove 'foo' pool created above
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            state: "absent"
-            volumes:
-              - name: test1
+      always:
+        - name: Remove 'foo' pool created above
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                state: "absent"
+                volumes:
+                  - name: test1
 
     - name: Verify role results
       include_tasks: verify-role-results.yml

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -254,71 +254,74 @@
 
     # For ext2 FS
 
-    - name: >-
-        Create a LVM logical volume with for ext2 FS size
-        {{ volume_size_before }}
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            type: lvm
-            disks: "{{ unused_disks }}"
-            volumes:
-              - name: test1
-                fs_type: ext2
-                size: "{{ volume_size_before }}"
-                mount_point: "{{ mount_location }}"
+    - name: Test ext2
+      block:
+        - name: >-
+            Create a LVM logical volume with for ext2 FS size
+            {{ volume_size_before }}
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    fs_type: ext2
+                    size: "{{ volume_size_before }}"
+                    mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Change volume size to {{ volume_size_after }}
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            type: lvm
-            disks: "{{ unused_disks }}"
-            volumes:
-              - name: test1
-                fs_type: ext2
-                size: "{{ volume_size_after }}"
-                mount_point: "{{ mount_location }}"
+        - name: Change volume size to {{ volume_size_after }}
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    fs_type: ext2
+                    size: "{{ volume_size_after }}"
+                    mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Change volume size to {{ volume_size_before }}
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            type: lvm
-            disks: "{{ unused_disks }}"
-            volumes:
-              - name: test1
-                fs_type: ext2
-                size: "{{ volume_size_before }}"
-                mount_point: "{{ mount_location }}"
+        - name: Change volume size to {{ volume_size_before }}
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                type: lvm
+                disks: "{{ unused_disks }}"
+                volumes:
+                  - name: test1
+                    fs_type: ext2
+                    size: "{{ volume_size_before }}"
+                    mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
-      vars:
-        storage_pools:
-          - name: foo
-            disks: "{{ unused_disks }}"
-            state: absent
-            volumes:
-              - name: test1
-                size: "{{ volume_size_before }}"
-                mount_point: "{{ mount_location }}"
+      always:
+        - name: Clean up
+          include_role:
+            name: linux-system-roles.storage
+          vars:
+            storage_pools:
+              - name: foo
+                disks: "{{ unused_disks }}"
+                state: absent
+                volumes:
+                  - name: test1
+                    size: "{{ volume_size_before }}"
+                    mount_point: "{{ mount_location }}"
 
     - name: Verify role results
       include_tasks: verify-role-results.yml
@@ -348,66 +351,68 @@
         is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
     # For ext4 FS -- online resize
-
-    - name: Run test on supported platforms
-      when: ((is_fedora and blivet_pkg_version is version("3.7.1-3", ">=")) or
-             (is_rhel8 and blivet_pkg_version is version("3.6.0-6", ">=")) or
-             (is_rhel9 and blivet_pkg_version is version("3.6.0-8", ">=")) or
-             is_rhel10)
+    - name: Test ext4 online resize
       block:
-        - name: >-
-            Create one LVM logical volume under one volume group with size
-            {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks }}"
-                type: lvm
-                volumes:
-                  - name: test1
-                    fs_type: ext4
-                    size: "{{ volume_size_before }}"
-                    mount_point: "{{ mount_location }}"
-
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
-
-        - name: Change volume_size to {{ volume_size_after }}
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                type: lvm
-                disks: "{{ unused_disks }}"
-                volumes:
-                  - name: test1
-                    fs_type: ext4
-                    size: "{{ volume_size_after }}"
-                    mount_point: "{{ mount_location }}"
-
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
-
-        - name: Test for correct handling of offline resize in safe mode
-          include_tasks: verify-role-failed.yml
-          vars:
-            __storage_failed_regex: must be unmounted to be resized in safe mode
-            __storage_failed_msg: >-
-              Unexpected behavior w/ resize in safe mode
-            __storage_failed_params:
-              storage_safe_mode: true
+      - name: Run test on supported platforms
+        when: ((is_fedora and blivet_pkg_version is version("3.7.1-3", ">=")) or
+              (is_rhel8 and blivet_pkg_version is version("3.6.0-6", ">=")) or
+              (is_rhel9 and blivet_pkg_version is version("3.6.0-8", ">=")) or
+              is_rhel10)
+        block:
+          - name: >-
+              Create one LVM logical volume under one volume group with size
+              {{ volume_size_before }}
+            include_role:
+              name: linux-system-roles.storage
+            vars:
               storage_pools:
                 - name: foo
                   disks: "{{ unused_disks }}"
+                  type: lvm
                   volumes:
                     - name: test1
                       fs_type: ext4
                       size: "{{ volume_size_before }}"
                       mount_point: "{{ mount_location }}"
 
+          - name: Verify role results
+            include_tasks: verify-role-results.yml
+
+          - name: Change volume_size to {{ volume_size_after }}
+            include_role:
+              name: linux-system-roles.storage
+            vars:
+              storage_pools:
+                - name: foo
+                  type: lvm
+                  disks: "{{ unused_disks }}"
+                  volumes:
+                    - name: test1
+                      fs_type: ext4
+                      size: "{{ volume_size_after }}"
+                      mount_point: "{{ mount_location }}"
+
+          - name: Verify role results
+            include_tasks: verify-role-results.yml
+
+          - name: Test for correct handling of offline resize in safe mode
+            include_tasks: verify-role-failed.yml
+            vars:
+              __storage_failed_regex: must be unmounted to be resized in safe mode
+              __storage_failed_msg: >-
+                Unexpected behavior w/ resize in safe mode
+              __storage_failed_params:
+                storage_safe_mode: true
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    volumes:
+                      - name: test1
+                        fs_type: ext4
+                        size: "{{ volume_size_before }}"
+                        mount_point: "{{ mount_location }}"
+
+      always:
         - name: Clean up
           include_role:
             name: linux-system-roles.storage


### PR DESCRIPTION
This should fix the `tests_remove_mount.yml` and `tests_existing_lvm_pool.yml` follow-up failures from https://github.com/linux-system-roles/storage/pull/518#issuecomment-2803840784 . It should also make `tests_lvm_pool_pv_grow.yml` fail "correctly", i.e. with the "Unexpected difference between PV size" error (which you get when running  this in isolation), instead of the "/dev/foo: already exists in filesystem" which is due to a dirty VM.