### PR TITLE
fix: Show error when trying to put LVM volume on partition pool

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1175,6 +1175,9 @@ class BlivetLVMVolume(BlivetVolume):
         if self._device:
             return
 
+        if self._blivet_pool._device and self._blivet_pool._device.type != "lvmvg":
+            raise BlivetAnsibleError("LVM volume can be placed only on LVM pool")
+
         thin_pool = self._volume.get('thin')
         use_vdo = self._volume['deduplication'] or self._volume['compression']
         use_lvmraid = self._volume['raid_level']

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -194,3 +194,31 @@
             type: lvm
             disks: "{{ unused_disks }}"
             state: absent
+
+    - name: Test for correct handling of pool and volume type mismatch
+      include_tasks: verify-role-failed.yml
+      vars:
+        storage_safe_mode: false
+        __storage_failed_regex: LVM volume can be placed only on LVM pool
+        __storage_failed_msg: Role did not report that wrong pool type was selected
+        __storage_failed_params:
+          storage_pools:
+            - name: foo
+              disks: "{{ unused_disks }}"
+              type: partition
+              volumes:
+                - name: test1
+                  type: lvm
+                  size: "{{ volume1_size }}"
+                  mount_point: "{{ mount_location1 }}"
+
+    - name: Clean up
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_safe_mode: false
+        storage_pools:
+          - name: testpool1
+            type: lvm
+            disks: "{{ unused_disks }}"
+            state: absent


### PR DESCRIPTION
Trying this currently fails later with an exception so this just makes sure we show a nicer error message describing the error in the provided playbook.

Resolves: RHEL-71246

## Summary by Sourcery

Provide explicit error handling when attempting to create an LVM volume on a non-LVM pool and add a test to verify this scenario

Bug Fixes:
- Raise a clear error when placing an LVM volume on a non-LVM (partition) pool

Tests:
- Add a test case to validate the pool and volume type mismatch triggers the correct error message