### PR TITLE
docs(changelog): version 1.18.16 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+[1.18.16] - 2025-05-16
+--------------------
+
+### Bug Fixes
+
+- fix: Allow small size differences to match the device min size (#526)
+- fix: Show error when trying to put LVM volume on partition pool (#531)
+
+### Other Changes
+
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#527)
+
 [1.18.15] - 2025-05-02
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.18.16

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare v1.18.16 release by updating documentation, applying bug fixes, and bumping CI dependencies.

Bug Fixes:
- Allow small size differences to match the device minimum size
- Show an error when placing an LVM volume on a partition pool

CI:
- Bump tox-lsr to 3.8.0 and rename qemu/kvm tests

Documentation:
- Update CHANGELOG and .README.html for version 1.18.16