### PR TITLE
fix: Fix getting PVs from raid_disks for RAID LVs

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1091,9 +1091,16 @@ class BlivetLVMVolume(BlivetVolume):
 
             for path in self._volume['raid_disks']:
                 disk = self._blivet.devicetree.resolve_device(path)
-                for pv in parent_device.pvs:
-                    if disk in pv.parents:
-                        pvs.append(pv)
+                if disk:
+                    for pv in parent_device.pvs:
+                        if pv == disk or disk in pv.ancestors:
+                            pvs.append(pv)
+                            break
+                    else:
+                        raise BlivetAnsibleError("Disk %s specified in raid_disks doesn't seem "
+                                                 "to be a PV of %s" % (path, parent_device.name))
+                else:
+                    raise BlivetAnsibleError("disk %s specified in raid_disks not found" % path)
 
         else:
             pvs = parent_device.pvs

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -244,6 +244,46 @@
     - name: Verify role results
       include_tasks: verify-role-results.yml
 
+    - name: Create a RAID1 lvm raid device on encrypted VG
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: present
+            encryption: true
+            encryption_password: yabbadabbadoo
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+                mount_point: "{{ mount_location1 }}"
+                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                raid_level: raid0
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
+    - name: Remove the device created above
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            disks: "{{ unused_disks }}"
+            type: lvm
+            state: absent
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+                mount_point: "{{ mount_location1 }}"
+                raid_level: raid0
+                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+    - name: Verify role results
+      include_tasks: verify-role-results.yml
+
     - name: Run test on supported platforms
       when: ((is_fedora and blivet_pkg_version is version("3.7.1-2", ">=")) or
              (is_rhel8 and blivet_pkg_version is version("3.6.0-5", ">=")) or


### PR DESCRIPTION
Currently the code expects the disks specified in raid_disks are parent devices of the PVs we are going to use to allocate the RAID LVs. This might not be true in several cases, for example if the VG is encrypted (the LUKS device introduces a new layer in the storage stack) or if partitions are not used (the disk is then the PV and doesn't have a parent). This fix also allows user to specify the PV partition instead of the underlying disk.

## Summary by Sourcery

Improve PV resolution in LVM RAID to support encrypted and partitioned devices and add corresponding tests

Bug Fixes:
- Fix PV detection for raid_disks entries to handle encrypted LUKS layers and direct partitions

Enhancements:
- Add error handling for missing or invalid raid_disks entries

Tests:
- Add tests for creating and removing LVM RAID devices on encrypted volume groups