### PR TITLE
refactor: Ansible 2.19 support

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -10,12 +10,12 @@
 
 - name: Show storage_pools
   debug:
-    var: storage_pools
+    var: storage_pools | d([])
     verbosity: 1
 
 - name: Show storage_volumes
   debug:
-    var: storage_volumes
+    var: storage_volumes | d([])
     verbosity: 1
 
 - name: Get required packages
@@ -177,7 +177,7 @@
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: true
-  when: blivet_output['mounts']
+  when: blivet_output['mounts'] | length > 0
 
 - name: Set up new/current mounts
   mount:  # noqa fqcn
@@ -209,7 +209,7 @@
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: true
-  when: blivet_output['mounts']
+  when: blivet_output['mounts'] | length > 0
 
 #
 # Manage /etc/crypttab

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -54,7 +54,10 @@
 - name: Set expected pv type
   set_fact:
     _storage_test_expected_pv_type: "{{ storage_test_pool.raid_level }}"
-  when: storage_test_pool.type == 'lvm' and storage_test_pool.raid_level
+  when:
+    - storage_test_pool.type == 'lvm'
+    - not storage_test_pool.raid_level is none
+    - storage_test_pool.raid_level | length > 0
 
 - name: Check the type of each PV
   assert:

--- a/tests/test-verify-volume-encryption.yml
+++ b/tests/test-verify-volume-encryption.yml
@@ -64,7 +64,8 @@
   when:
     - _storage_test_volume_present
     - storage_test_volume.encryption
-    - storage_test_volume.encryption_luks_version
+    - not storage_test_volume.encryption_luks_version is none
+    - storage_test_volume.encryption_luks_version | length > 0
 
 - name: Check LUKS key size
   assert:
@@ -79,7 +80,8 @@
   when:
     - _storage_test_volume_present
     - storage_test_volume.encryption
-    - storage_test_volume.encryption_key_size
+    - not storage_test_volume.encryption_key_size is none
+    - storage_test_volume.encryption_key_size > 0
 
 - name: Check LUKS cipher
   assert:
@@ -96,7 +98,8 @@
   when:
     - _storage_test_volume_present
     - storage_test_volume.encryption
-    - storage_test_volume.encryption_cipher
+    - not storage_test_volume.encryption_cipher is none
+    - storage_test_volume.encryption_cipher | length > 0
 
 - name: Set test variables
   set_fact:

--- a/tests/test-verify-volume-fs.yml
+++ b/tests/test-verify-volume-fs.yml
@@ -10,7 +10,7 @@
           (storage_test_blkinfo.info[storage_test_volume._device].fstype | length
           == 0 and storage_test_volume.fs_type == "unformatted")
       when:
-        - storage_test_volume.fs_type
+        - storage_test_volume.fs_type | length > 0
         - _storage_test_volume_present
 
     # label

--- a/tests/test-verify-volume-mount.yml
+++ b/tests/test-verify-volume-mount.yml
@@ -32,11 +32,13 @@
   stat:
     path: "{{ storage_test_volume.mount_point }}"
   register: storage_test_found_mount_stat
-  when: _storage_test_volume_present and
-        storage_test_volume.mount_point and
-        (storage_test_volume.mount_user or
-         storage_test_volume.mount_group or
-         storage_test_volume.mount_mode)
+  when:
+    - _storage_test_volume_present | bool
+    - not storage_test_volume.mount_point is none
+    - storage_test_volume.mount_point | length > 0
+    - (not storage_test_volume.mount_user is none and storage_test_volume.mount_user | length > 0) or
+      (not storage_test_volume.mount_group is none and storage_test_volume.mount_group | length > 0) or
+      (not storage_test_volume.mount_mode is none and storage_test_volume.mount_mode | length > 0)
 
 #
 # Verify mount presence.
@@ -58,9 +60,12 @@
           {{ storage_test_volume.name }}) has unexpected owner
           (expected: {{ storage_test_volume.mount_user }}, found:
           {{ storage_test_found_mount_stat.stat.pw_name }})"
-  when: _storage_test_volume_present and
-        storage_test_volume.mount_point and
-        storage_test_volume.mount_user
+  when:
+    - _storage_test_volume_present
+    - not storage_test_volume.mount_point is none
+    - storage_test_volume.mount_point | length > 0
+    - not storage_test_volume.mount_user is none
+    - storage_test_volume.mount_user | length > 0
 
 - name: Verify mount directory group
   assert:
@@ -70,9 +75,12 @@
           {{ storage_test_volume.name }}) has unexpected group
           (expected: {{ storage_test_volume.mount_group }}, found:
           {{ storage_test_found_mount_stat.stat.gr_name }})"
-  when: _storage_test_volume_present and
-        storage_test_volume.mount_point and
-        storage_test_volume.mount_group
+  when:
+    - _storage_test_volume_present
+    - not storage_test_volume.mount_point is none
+    - storage_test_volume.mount_point | length > 0
+    - not storage_test_volume.mount_group is none
+    - storage_test_volume.mount_group | length > 0
 
 - name: Verify mount directory permissions
   assert:
@@ -82,9 +90,12 @@
           {{ storage_test_volume.name }}) has unexpected permissions (expected:
           {{ storage_test_volume.mount_mode }}, found:
           {{ storage_test_found_mount_stat.stat.mode }})"
-  when: _storage_test_volume_present and
-        storage_test_volume.mount_point and
-        storage_test_volume.mount_mode
+  when:
+    - _storage_test_volume_present
+    - not storage_test_volume.mount_point is none
+    - storage_test_volume.mount_point | length > 0
+    - not storage_test_volume.mount_mode is none
+    - storage_test_volume.mount_mode | length > 0
 
 #
 # Verify swap status.

--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -62,7 +62,8 @@
 
 - name: Process thin pool sizes when applicable
   when:
-    - storage_test_volume.thin
+    - not storage_test_volume.thin is none
+    - storage_test_volume.thin | bool
     - _storage_test_volume_present | bool
   block:
     - name: Default thin pool reserved space values

--- a/tests/test-verify-volume.yml
+++ b/tests/test-verify-volume.yml
@@ -15,10 +15,10 @@
     #     compression
     #     deduplication
     _storage_test_volume_present: "{{ storage_test_volume.state == 'present' and
-      (not storage_test_pool | default() or
+      (storage_test_pool | default({}) | length == 0 or
        storage_test_pool.state == 'present') }}"
 
-- name: Run test verify for {{ storage_test_volume_subset }}
+- name: Run test verify for storage_test_volume_subset
   include_tasks: test-verify-volume-{{ storage_test_volume_subset }}.yml
   loop: "{{ _storage_volume_tests }}"
   loop_control:

--- a/tests/verify-pool-member-encryption.yml
+++ b/tests/verify-pool-member-encryption.yml
@@ -35,7 +35,8 @@
   when:
     - storage_test_pool.state == 'present'
     - storage_test_pool.encryption
-    - storage_test_pool.encryption_luks_version
+    - not storage_test_pool.encryption_luks_version is none
+    - storage_test_pool.encryption_luks_version | length > 0
 
 - name: Check LUKS key size
   assert:
@@ -50,7 +51,8 @@
   when:
     - storage_test_pool.state == 'present'
     - storage_test_pool.encryption
-    - storage_test_pool.encryption_key_size
+    - not storage_test_pool.encryption_key_size is none
+    - storage_test_pool.encryption_key_size > 0
 
 - name: Check LUKS cipher
   assert:
@@ -67,4 +69,5 @@
   when:
     - storage_test_pool.state == 'present'
     - storage_test_pool.encryption
-    - storage_test_pool.encryption_cipher
+    - not storage_test_pool.encryption_cipher is none
+    - storage_test_pool.encryption_cipher | length > 0

--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -44,13 +44,15 @@
 
     - name: Verify correct exception or error message
       assert:
-        that: exception is search(__storage_failed_exception) or
+        that: msg_msg is search(__storage_failed_exception) or
+          exception is search(__storage_failed_exception) or
           msg_stdout is search(__storage_failed_exception) or
           msg_stderr is search(__storage_failed_exception) or
           stdout is search(__storage_failed_exception) or
           stderr is search(__storage_failed_exception)
       when: __storage_failed_exception is defined
       vars:
+        msg_msg: "{{ ansible_failed_result.msg.msg | d('') }}"
         exception: "{{ ansible_failed_result.msg.exception | d('') }}"
         msg_stdout: "{{ ansible_failed_result.msg.module_stdout | d('') }}"
         msg_stderr: "{{ ansible_failed_result.msg.module_stderr | d('') }}"

--- a/tests/verify-role-results.yml
+++ b/tests/verify-role-results.yml
@@ -33,20 +33,18 @@
 #
 - name: Verify the volumes listed in storage_pools were correctly managed
   include_tasks: "test-verify-pool.yml"
-  loop: "{{ _storage_pools_list }}"
+  loop: "{{ _storage_pools_list | d([]) }}"
   loop_control:
     loop_var: storage_test_pool
-  when: _storage_pools_list is defined and _storage_pools_list | length > 0
 
 #
 # Verify standalone volumes.
 #
 - name: Verify the volumes with no pool were correctly managed
   include_tasks: "test-verify-volume.yml"
-  loop: "{{ _storage_volumes_list }}"
+  loop: "{{ _storage_volumes_list | d([]) }}"
   loop_control:
     loop_var: storage_test_volume
-  when: _storage_volumes_list is defined and _storage_volumes_list | length > 0
 
 #
 # Clean up.


### PR DESCRIPTION
Ansible 2.19 introduces some big changes
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_core_2.19.html

One big change is that data structures are no longer mutable by the use of python
methods such as `__setitem__`, `setdefault`, `update`, etc.  in Jinja constructs.
Instead, items must use filters or other Jinja operations.

One common idiom is to mutate each element in a list.  Since we cannot do this
"in-place" anymore, a common way to do this is:

```yaml
- name: Construct a new list from an existing list and mutate each element
  set_fact:
    __new_list: "{{ __new_list | d([]) + [mutated_item] }}"
  loop: "{{ old_list }}"
  mutated_item: "{{ some value based on item from old list }}"

- name: Reset original old list
  set_fact:
    old_list: "{{ __new_list }}"
```

Similarly with `dict` items:

```yaml
- name: Construct a new dict from an existing dict and mutate each element
  set_fact:
    __new_dict: "{{ __new_dict | d({}) | combine(mutated_item) }}"
  loop: "{{ old_dict | dict2items }}"
  mutated_item: "{{ {item.key: mutation of item.value} }}"

- name: Reset original old dict
  set_fact:
    old_dict: "{{ __new_dict }}"
```

Another big change is that a boolean expression in a `when` or similar construct
must be converted to a boolean - we cannot rely on the implicit evaluation in
a boolean context.  For example, if `var` is some iterable, like a `dict`, `list`,
or `string`, you used to be able to evaluate an empty value in a boolean context:

```yaml
when: var  # do this only if var is not empty
```

You now have to explicitly test for empty using `length`:

```yaml
when: var | length > 0  # do this only if var is not empty
```

Similarly for `int` values - you cannot rely on `0` being evaluated as false
and non-zero true - you must explicitly compare the values with `==` or `!=`

These are the biggest changes.  See the porting guide for others.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Port playbooks and tests to comply with Ansible 2.19 by replacing implicit mutability and boolean contexts with explicit filters and defaults

Enhancements:
- Convert all `when` conditions to use explicit `| bool`, `| length`, or `not is none` checks to avoid implicit truth evaluation
- Add default filters (`| d([])` and `| d({})`) on lists and dicts before looping or debugging to ensure defined values
- Replace implicit dictionary and list mutations with Jinja filters and operations in test tasks
- Rename mis-referenced test variable to correctly capture failure messages

Tests:
- Update test playbooks to use explicit length and boolean filters for volume mount, encryption, pool member, and filesystem checks