### PR TITLE
docs(changelog): version 1.18.17 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+[1.18.17] - 2025-06-16
+--------------------
+
+### Bug Fixes
+
+- fix: Fix getting PVs from raid_disks for RAID LVs (#536)
+
+### Other Changes
+
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#534)
+- ci: Add support for bootc end-to-end validation tests (#537)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#538)
+- refactor: Ansible 2.19 support (#540)
+
 [1.18.16] - 2025-05-16
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.18.17

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update changelog for version 1.18.17 with a RAID LVs bug fix, CI enhancements for Fedora 42 and Ansible 2.19 support, and related refactoring.

Bug Fixes:
- Fix getting PVs from raid_disks for RAID LVs (#536)

Enhancements:
- Refactor playbooks for Ansible 2.19 compatibility (#540)

CI:
- Add Fedora 42 testing; use tox-lsr 3.9.0 and lsr-report-errors for QEMU tests (#534)
- Add support for bootc end-to-end validation tests (#537)
- Use Ansible 2.19 and support Python 3.13 for Fedora 42 testing (#538)