### PR TITLE
refactor: make task names unique; fix indentation

### DIFF
--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -45,13 +45,13 @@
       if storage_test_pool.encryption else 'disk' }}"
   when: storage_test_pool.type == 'lvm'
 
-- name: Set expected pv type
+- name: Set expected pv type - 2
   set_fact:
     _storage_test_expected_pv_type: "{{ 'partition'
       if storage_use_partitions | d(false) else 'disk' }}"
   when: storage_test_pool.type == 'lvm' and not storage_test_pool.encryption
 
-- name: Set expected pv type
+- name: Set expected pv type - 3
   set_fact:
     _storage_test_expected_pv_type: "{{ storage_test_pool.raid_level }}"
   when:

--- a/tests/test-verify-volume-device.yml
+++ b/tests/test-verify-volume-device.yml
@@ -13,7 +13,7 @@
       Incorrect device node presence for volume {{ storage_test_volume.name }}
   when: _storage_test_volume_present or storage_test_volume.type == 'disk'
 
-- name: Verify the presence/absence of the device node
+- name: Verify the presence/absence of the device node - 2
   assert:
     that: not storage_test_dev.stat.exists
     msg: >-

--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -127,7 +127,7 @@
         - storage_test_volume.thin_pool_size is not none
         - "'%' not in storage_test_volume.thin_pool_size"
 
-    - name: Calculate the expected size based on pool size and percentage value
+    - name: Calculate the expected size based on pool size and percentage value - 2
       set_fact:
         storage_test_expected_thin_pool_size: "{{
           (_storage_test_max_thin_pool_size.bytes *
@@ -158,7 +158,7 @@
   debug:
     var: storage_test_actual_size
 
-- name: Show expected size
+- name: Show expected size - 2
   debug:
     var: storage_test_expected_size
 

--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -54,7 +54,7 @@
             fs_type: "{{ fs_type_after }}"
             disks: "{{ unused_disks }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -68,7 +68,7 @@
             fs_type: "{{ fs_type_after }}"
             disks: "{{ unused_disks }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -82,5 +82,5 @@
             mount_point: "{{ mount_location }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_change_disk_mount.yml
+++ b/tests/tests_change_disk_mount.yml
@@ -50,7 +50,7 @@
             mount_point: "{{ mount_location_after }}"
             disks: "{{ unused_disks }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -63,7 +63,7 @@
             mount_point: "{{ mount_location_after }}"
             disks: "{{ unused_disks }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -77,5 +77,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -60,7 +60,7 @@
                 fs_type: "{{ fs_after }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Re-run the role on the same volume without specifying fs_type
@@ -82,7 +82,7 @@
           - blivet_output.pools[0].volumes[0].fs_type == fs_after
         msg: Failed to preserve omitted fs_type on existing lvm volume
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -98,7 +98,7 @@
                 fs_type: "{{ fs_after }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
     - name: Remove the FS
@@ -113,7 +113,7 @@
                 size: "{{ volume_size }}"
                 fs_type: unformatted
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
 
@@ -131,5 +131,5 @@
                 fs_type: "{{ fs_after }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 6
       include_tasks: verify-role-results.yml

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -61,7 +61,7 @@
                 fs_type: "{{ fs_type_after }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -77,7 +77,7 @@
                 fs_type: "{{ fs_type_after }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -95,5 +95,5 @@
                 mount_point: "{{ mount_location }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_change_mount.yml
+++ b/tests/tests_change_mount.yml
@@ -56,7 +56,7 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -71,7 +71,7 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -87,5 +87,5 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -64,7 +64,7 @@
           - blivet_output.volumes[0].fs_type == 'ext4'
         msg: File system not preserved on existing partition volume.
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above
@@ -78,5 +78,5 @@
             mount_point: "{{ mount_location }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -59,5 +59,5 @@
               - name: test1
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_lvm_cache_then_remove.yml
+++ b/tests/tests_create_lvm_cache_then_remove.yml
@@ -86,7 +86,7 @@
                 size: "{{ volume_size }}"
                 cached: false
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Run test on supported platforms
@@ -109,7 +109,7 @@
                     cache_size: "{{ cache_size }}"
                     cache_devices: "{{ [unused_disks[1]] }}"
 
-        - name: Verify role results
+        - name: Verify role results - 3
           include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -124,5 +124,5 @@
               - name: test
                 size: "{{ volume_size }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -67,7 +67,7 @@
                 mount_point: "{{ mount_location2 }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -86,7 +86,7 @@
                 mount_point: "{{ mount_location2 }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Remove both of the LVM logical volumes in 'foo' created above
@@ -105,5 +105,5 @@
                 size: "{{ volume2_size }}"
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -101,7 +101,7 @@
                     size: "{{ volume_size }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 2
           include_tasks: verify-role-results.yml
 
         - name: Remove LVM VDO volume in 'pool1' created above
@@ -120,7 +120,7 @@
                     size: "{{ volume_size }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 3
           include_tasks: verify-role-results.yml
 
         - name: >-
@@ -139,10 +139,10 @@
                     size: "{{ volume_size }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 4
           include_tasks: verify-role-results.yml
 
-        - name: Remove LVM VDO volume in 'pool1' created above
+        - name: Remove LVM VDO volume in 'pool1' created above - 2
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -157,5 +157,5 @@
                     size: "{{ volume_size }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 5
           include_tasks: verify-role-results.yml

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -62,7 +62,7 @@
           - blivet_output.pools[0].volumes[0].fs_type == 'ext4'
         msg: File system not preserved on existing partition volume.
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove the partition created above
@@ -80,7 +80,7 @@
                 mount_point: "{{ mount_location }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -98,5 +98,5 @@
                 mount_point: "{{ mount_location }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -103,7 +103,7 @@
                 size: "{{ volume3_size }}"
                 mount_point: "{{ mount_location3 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove the device created above
@@ -127,7 +127,7 @@
                 size: "{{ volume3_size }}"
                 mount_point: "{{ mount_location3 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID1 lvm raid device
@@ -146,10 +146,10 @@
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
                 raid_level: raid1
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
-    - name: Repeat the previous invocation to verify idempotence
+    - name: Repeat the previous invocation to verify idempotence - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -165,10 +165,10 @@
                 raid_level: raid1
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
-    - name: Remove the device created above
+    - name: Remove the device created above - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -184,7 +184,7 @@
                 raid_level: raid1
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-    - name: Verify role results
+    - name: Verify role results - 6
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID0 lvm raid device
@@ -203,10 +203,10 @@
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
                 raid_level: raid0
 
-    - name: Verify role results
+    - name: Verify role results - 7
       include_tasks: verify-role-results.yml
 
-    - name: Repeat the previous invocation to verify idempotence
+    - name: Repeat the previous invocation to verify idempotence - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -222,10 +222,10 @@
                 raid_level: raid0
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-    - name: Verify role results
+    - name: Verify role results - 8
       include_tasks: verify-role-results.yml
 
-    - name: Remove the device created above
+    - name: Remove the device created above - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -241,7 +241,7 @@
                 raid_level: raid0
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-    - name: Verify role results
+    - name: Verify role results - 9
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID1 lvm raid device on encrypted VG
@@ -262,10 +262,10 @@
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
                 raid_level: raid0
 
-    - name: Verify role results
+    - name: Verify role results - 10
       include_tasks: verify-role-results.yml
 
-    - name: Remove the device created above
+    - name: Remove the device created above - 4
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -281,7 +281,7 @@
                 raid_level: raid0
                 raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-    - name: Verify role results
+    - name: Verify role results - 11
       include_tasks: verify-role-results.yml
 
     - name: Run test on supported platforms
@@ -307,10 +307,10 @@
                     raid_level: raid0
                     raid_stripe_size: "256 KiB"
 
-        - name: Verify role results
+        - name: Verify role results - 12
           include_tasks: verify-role-results.yml
 
-        - name: Remove the device created above
+        - name: Remove the device created above - 5
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -326,5 +326,5 @@
                     raid_level: raid0
                     raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-        - name: Verify role results
+        - name: Verify role results - 13
           include_tasks: verify-role-results.yml

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -52,7 +52,7 @@
             disks: "{{ unused_disks }}"
             mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above
@@ -67,5 +67,5 @@
             mount_point: "{{ mount_location }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_create_thinp_then_remove.yml
+++ b/tests/tests_create_thinp_then_remove.yml
@@ -61,7 +61,7 @@
                 thin: true
                 mount_point: "{{ mount_location1 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Change thinlv fs type
@@ -78,7 +78,7 @@
                 thin: true
                 fs_type: "{{ fs_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Create new LV under existing thinpool
@@ -96,7 +96,7 @@
                 thin: true
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
     - name: Remove existing LV under existing thinpool
@@ -114,7 +114,7 @@
                 mount_point: "{{ mount_location2 }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
     - name: Cleanup
@@ -134,7 +134,7 @@
                 thin: true
                 mount_point: "{{ mount_location1 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 6
       include_tasks: verify-role-results.yml
 
     - name: Create a thinpool device using percentages
@@ -154,10 +154,10 @@
                 thin: true
                 mount_point: "{{ mount_location1 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 7
       include_tasks: verify-role-results.yml
 
-    - name: Cleanup
+    - name: Cleanup - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -174,5 +174,5 @@
                 thin: true
                 mount_point: "{{ mount_location1 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 8
       include_tasks: verify-role-results.yml

--- a/tests/tests_deps.yml
+++ b/tests/tests_deps.yml
@@ -46,7 +46,7 @@
             fs_type: ext4
             encryption: false
 
-    - name: Assert unexpected required package list is empty
+    - name: Assert unexpected required package list is empty - 2
       assert:
         that:
           - blivet_output.packages == ['e2fsprogs']
@@ -65,7 +65,7 @@
             fs_type: swap
             encryption: false
 
-    - name: Assert unexpected required package list is empty
+    - name: Assert unexpected required package list is empty - 3
       assert:
         that:
           - blivet_output.packages == []

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -129,7 +129,7 @@
         that: stat_r.stat.isreg is defined and stat_r.stat.isreg
         msg: data lost!
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -156,12 +156,12 @@
               disks: "{{ unused_disks }}"
               type: lvm
 
-    - name: Stat the file
+    - name: Stat the file - 2
       stat:
         path: "{{ testfile }}"
       register: stat_r
 
-    - name: Assert file presence
+    - name: Assert file presence - 2
       assert:
         that: stat_r.stat.isreg is defined and stat_r.stat.isreg
         msg: data lost!

--- a/tests/tests_existing_lvm_pool.yml
+++ b/tests/tests_existing_lvm_pool.yml
@@ -56,7 +56,7 @@
                 fs_type: ext4
                 fs_label: newvol
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Clean up.
@@ -67,5 +67,5 @@
           - name: "{{ pool_name }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_filesystem_one_disk.yml
+++ b/tests/tests_filesystem_one_disk.yml
@@ -47,7 +47,7 @@
             mount_point: "{{ mount_location }}"
             disks: "{{ unused_disks }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -61,5 +61,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -37,11 +37,11 @@
         - ansible_facts["distribution_major_version"] | int > 7
         - ansible_facts["distribution_major_version"] | int < 10
       block:
-        - name: Enable FIPS mode
+        - name: Enable FIPS mode - 2
           command: fips-mode-setup --enable
           changed_when: false
 
-        - name: Reboot
+        - name: Reboot - 2
           reboot:
             test_command: fips-mode-setup --check
 
@@ -67,7 +67,7 @@
             kernel=$(grubby --default-kernel)
             grubby --update-kernel=$kernel --args=fips=1
 
-        - name: Reboot
+        - name: Reboot - 3
           reboot:
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
@@ -150,13 +150,13 @@
             encryption: false
             encryption_password: yabbadabbadoo
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 2
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -173,7 +173,7 @@
               encryption: true
               encryption_password: yabbadabbadoo
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 2
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume
@@ -189,14 +189,14 @@
             encryption: true
             encryption_password: yabbadabbadoo
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     ##
     ## Partition
     ##
 
-    - name: Test for correct handling of new encrypted volume w/ no key
+    - name: Test for correct handling of new encrypted volume w/ no key - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: encrypted volume.*missing key
@@ -232,13 +232,13 @@
                 encryption: true
                 encryption_password: yabbadabbadoo
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 3
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 3
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -259,10 +259,10 @@
                   encryption: false
                   encryption_password: yabbadabbadoo
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 3
       import_tasks: verify-data-preservation.yml
 
-    - name: Remove the encryption layer
+    - name: Remove the encryption layer - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -279,13 +279,13 @@
                 encryption: false
                 encryption_password: yabbadabbadoo
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 4
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 4
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -306,7 +306,7 @@
                   encryption: true
                   encryption_password: yabbadabbadoo
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 4
       import_tasks: verify-data-preservation.yml
 
     - name: Test key file handling
@@ -325,7 +325,7 @@
             mode: "0600"
           changed_when: false
 
-        - name: Add encryption to the volume
+        - name: Add encryption to the volume - 2
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -342,7 +342,7 @@
                     encryption: true
                     encryption_key: "{{ storage_test_key_file.path }}"
 
-        - name: Verify role results
+        - name: Verify role results - 6
           include_tasks: verify-role-results.yml
       always:
         - name: Remove the key file
@@ -355,7 +355,7 @@
     ## LVM
     ##
 
-    - name: Test for correct handling of new encrypted volume w/ no key
+    - name: Test for correct handling of new encrypted volume w/ no key - 3
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: encrypted volume.*missing key
@@ -392,7 +392,7 @@
                 encryption_key_size: 512
                 encryption_cipher: "{{ __luks_cipher }}"
 
-    - name: Verify role results
+    - name: Verify role results - 7
       include_tasks: verify-role-results.yml
 
     - name: Verify preservation of encryption settings on existing LVM volume
@@ -416,13 +416,13 @@
           - blivet_output.pools[0].volumes[0].encryption
           - blivet_output.pools[0].volumes[0].encryption_luks_version == 'luks1'
 
-    - name: Verify role results
+    - name: Verify role results - 8
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 5
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 5
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -442,10 +442,10 @@
                   encryption: false
                   encryption_password: yabbadabbadoo
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 5
       import_tasks: verify-data-preservation.yml
 
-    - name: Remove the encryption layer
+    - name: Remove the encryption layer - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -461,13 +461,13 @@
                 encryption: false
                 encryption_password: yabbadabbadoo
 
-    - name: Verify role results
+    - name: Verify role results - 9
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 6
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 6
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -487,10 +487,10 @@
                   encryption: true
                   encryption_password: yabbadabbadoo
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 6
       import_tasks: verify-data-preservation.yml
 
-    - name: Add encryption to the volume
+    - name: Add encryption to the volume - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -506,7 +506,7 @@
                 encryption: true
                 encryption_password: yabbadabbadoo
 
-    - name: Verify role results
+    - name: Verify role results - 10
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -519,5 +519,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 11
       include_tasks: verify-role-results.yml

--- a/tests/tests_luks2.yml
+++ b/tests/tests_luks2.yml
@@ -37,11 +37,11 @@
         - ansible_facts["distribution_major_version"] | int > 7
         - ansible_facts["distribution_major_version"] | int < 10
       block:
-        - name: Enable FIPS mode
+        - name: Enable FIPS mode - 2
           command: fips-mode-setup --enable
           changed_when: false
 
-        - name: Reboot
+        - name: Reboot - 2
           reboot:
             test_command: fips-mode-setup --check
 
@@ -67,7 +67,7 @@
             kernel=$(grubby --default-kernel)
             grubby --update-kernel=$kernel --args=fips=1
 
-        - name: Reboot
+        - name: Reboot - 3
           reboot:
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
@@ -154,13 +154,13 @@
             encryption_password: yabbadabbadoo
             encryption_luks_version: luks2
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 2
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -178,7 +178,7 @@
               encryption_password: yabbadabbadoo
               encryption_luks_version: luks2
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 2
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume
@@ -195,14 +195,14 @@
             encryption_password: yabbadabbadoo
             encryption_luks_version: luks2
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     ##
     ## Partition
     ##
 
-    - name: Test for correct handling of new encrypted volume w/ no key
+    - name: Test for correct handling of new encrypted volume w/ no key - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: encrypted volume.*missing key
@@ -240,13 +240,13 @@
                 encryption_password: yabbadabbadoo
                 encryption_luks_version: luks2
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 3
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 3
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -268,10 +268,10 @@
                   encryption_password: yabbadabbadoo
                   encryption_luks_version: luks2
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 3
       import_tasks: verify-data-preservation.yml
 
-    - name: Remove the encryption layer
+    - name: Remove the encryption layer - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -289,13 +289,13 @@
                 encryption_password: yabbadabbadoo
                 encryption_luks_version: luks2
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 4
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 4
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -317,7 +317,7 @@
                   encryption_password: yabbadabbadoo
                   encryption_luks_version: luks2
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 4
       import_tasks: verify-data-preservation.yml
 
     - name: Test key file handling
@@ -336,7 +336,7 @@
             mode: "0600"
           changed_when: false
 
-        - name: Add encryption to the volume
+        - name: Add encryption to the volume - 2
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -354,7 +354,7 @@
                     encryption_key: "{{ storage_test_key_file.path }}"
                     encryption_luks_version: luks2
 
-        - name: Verify role results
+        - name: Verify role results - 6
           include_tasks: verify-role-results.yml
       always:
         - name: Remove the key file
@@ -367,7 +367,7 @@
     ## LVM
     ##
 
-    - name: Test for correct handling of new encrypted volume w/ no key
+    - name: Test for correct handling of new encrypted volume w/ no key - 3
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: encrypted volume.*missing key
@@ -405,7 +405,7 @@
                 encryption_key_size: 512
                 encryption_cipher: "{{ __luks_cipher }}"
 
-    - name: Verify role results
+    - name: Verify role results - 7
       include_tasks: verify-role-results.yml
 
     - name: Verify preservation of encryption settings on existing LVM volume
@@ -429,13 +429,13 @@
           - blivet_output.pools[0].volumes[0].encryption
           - blivet_output.pools[0].volumes[0].encryption_luks_version == 'luks2'
 
-    - name: Verify role results
+    - name: Verify role results - 8
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 5
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 5
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -456,10 +456,10 @@
                   encryption_password: yabbadabbadoo
                   encryption_luks_version: luks2
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 5
       import_tasks: verify-data-preservation.yml
 
-    - name: Remove the encryption layer
+    - name: Remove the encryption layer - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -476,13 +476,13 @@
                 encryption_password: yabbadabbadoo
                 encryption_luks_version: luks2
 
-    - name: Verify role results
+    - name: Verify role results - 9
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 6
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 6
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -503,10 +503,10 @@
                   encryption_password: yabbadabbadoo
                   encryption_luks_version: luks2
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 6
       import_tasks: verify-data-preservation.yml
 
-    - name: Add encryption to the volume
+    - name: Add encryption to the volume - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -523,7 +523,7 @@
                 encryption_password: yabbadabbadoo
                 encryption_luks_version: luks2
 
-    - name: Verify role results
+    - name: Verify role results - 10
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -536,5 +536,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 11
       include_tasks: verify-role-results.yml

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -21,7 +21,7 @@
         - ansible_facts["os_family"] == "RedHat"
         - ansible_facts["distribution_major_version"] | int > 7
       block:
-        - name: Enable FIPS mode
+        - name: Enable FIPS mode - 2
           command: fips-mode-setup --enable
           changed_when: false
 
@@ -29,7 +29,7 @@
           reboot:
             test_command: fips-mode-setup --check
 
-    - name: Enable FIPS mode
+    - name: Enable FIPS mode - 3
       when:
         - lookup("env", "SYSTEM_ROLES_TEST_FIPS") == "true"
         - ansible_facts["os_family"] == "RedHat"
@@ -51,7 +51,7 @@
             kernel=$(grubby --default-kernel)
             grubby --update-kernel=$kernel --args=fips=1
 
-        - name: Reboot
+        - name: Reboot - 2
           reboot:
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
@@ -92,7 +92,7 @@
                   mount_point: "{{ mount_location }}"
                   size: 4g
 
-    - name: Mark tasks to be skipped
+    - name: Mark tasks to be skipped - 2
       set_fact:
         storage_skip_checks:
           - blivet_available
@@ -182,13 +182,13 @@
                 mount_point: "{{ mount_location }}"
                 size: 4g
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 2
       import_tasks: create-test-file.yml
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -210,7 +210,7 @@
                   mount_point: "{{ mount_location }}"
                   size: 4g
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 2
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the pool
@@ -232,10 +232,10 @@
                 mount_point: "{{ mount_location }}"
                 size: 4g
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
-    - name: Create test file
+    - name: Create test file - 3
       import_tasks: create-test-file.yml
 
     - name: Change the mountpoint, leaving encryption in place
@@ -255,12 +255,12 @@
         that: blivet_output.pools[0].encryption
         msg: Failed to implicitly preserve encryption on existing pool.
 
-    - name: Verify data preservation
+    - name: Verify data preservation - 3
       import_tasks: verify-data-preservation.yml
       vars:
         testfile: "{{ testfile_location_2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -273,5 +273,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_auto_size_cap.yml
+++ b/tests/tests_lvm_auto_size_cap.yml
@@ -91,7 +91,7 @@
               - name: test1
                 size: "{{ test_disk_size }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Clean up

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -169,7 +169,7 @@
               disks: "{{ unused_disks }}"
               type: lvm
 
-    - name: Test for correct handling of safe_mode
+    - name: Test for correct handling of safe_mode - 2
       include_tasks: verify-role-failed.yml
       vars:
         __storage_failed_regex: >-
@@ -212,7 +212,7 @@
                   size: "{{ volume1_size }}"
                   mount_point: "{{ mount_location1 }}"
 
-    - name: Clean up
+    - name: Clean up - 2
       include_role:
         name: linux-system-roles.storage
       vars:

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -66,7 +66,7 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -79,5 +79,5 @@
             volumes: []
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_one_disk_multiple_volumes.yml
+++ b/tests/tests_lvm_one_disk_multiple_volumes.yml
@@ -67,7 +67,7 @@
                 size: "{{ volume_size }}"
                 mount_point: '/opt/test3'
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove two of the LVs
@@ -90,7 +90,7 @@
                 mount_point: '/opt/test3'
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Re-run the previous role invocation to ensure idempotence
@@ -113,7 +113,7 @@
                 mount_point: '/opt/test3'
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
     - name: Clean up

--- a/tests/tests_lvm_one_disk_one_volume.yml
+++ b/tests/tests_lvm_one_disk_one_volume.yml
@@ -56,7 +56,7 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -73,5 +73,5 @@
                 mount_point: "{{ mount_location }}"
                 state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -77,7 +77,7 @@
                 size: "{{ size2 }}"
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Shrink test2 volume via percentage-based size spec
@@ -95,7 +95,7 @@
                 size: "{{ size3 }}"
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Get the size of test2 volume
@@ -120,7 +120,7 @@
                 size: "{{ size3 }}"
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
     - name: Get the size of test2 volume again
@@ -146,7 +146,7 @@
                 size: "{{ size4 }}"
                 mount_point: "{{ mount_location2 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
     - name: Remove both of the LVM logical volumes in 'foo' created above
@@ -158,5 +158,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 6
       include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -88,7 +88,7 @@
               - name: foo
                 disks: "{{ unused_disks }}"
 
-        - name: Verify role results
+        - name: Verify role results - 2
           include_tasks: verify-role-results.yml
 
         - name: Get UUID of the 'foo' volume group
@@ -119,15 +119,15 @@
           assert:
             that: storage_test_removed_pttype.stdout == ''
 
-        - name: Verify role results
+        - name: Verify role results - 3
           include_tasks: verify-role-results.yml
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 2
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 2
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -140,15 +140,15 @@
               - name: foo
                 disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-        - name: Verify role results
+        - name: Verify role results - 4
           include_tasks: verify-role-results.yml
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 3
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 3
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -162,15 +162,15 @@
               - name: foo
                 disks: "{{ [unused_disks[1], unused_disks[2]] }}"
 
-        - name: Verify role results
+        - name: Verify role results - 5
           include_tasks: verify-role-results.yml
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 4
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 4
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -186,12 +186,12 @@
                 encryption_password: yabbadabbadoo
                 disks: "{{ unused_disks }}"
 
-        - name: Save UUID of the created volume group
+        - name: Save UUID of the created volume group - 2
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid
 
-        - name: Remove 2 PVs from the 'foo' volume group
+        - name: Remove 2 PVs from the 'foo' volume group - 2
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -201,15 +201,15 @@
                 encryption_password: yabbadabbadoo
                 disks: "{{ [unused_disks[0]] }}"
 
-        - name: Verify role results
+        - name: Verify role results - 6
           include_tasks: verify-role-results.yml
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 5
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 5
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -224,15 +224,15 @@
                 encryption_password: yabbadabbadoo
                 disks: "{{ unused_disks }}"
 
-        - name: Verify role results
+        - name: Verify role results - 7
           include_tasks: verify-role-results.yml
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 6
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 6
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -249,12 +249,12 @@
                   - name: test
                     size: "{{ volume_size }}"
 
-        - name: Save UUID of the created volume group
+        - name: Save UUID of the created volume group - 3
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid
 
-        - name: Verify role results
+        - name: Verify role results - 8
           include_tasks: verify-role-results.yml
 
         - name: Add a second PV to the VG
@@ -268,12 +268,12 @@
                   - name: test
                     size: "{{ volume_size }}"
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 7
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 7
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -289,22 +289,22 @@
                   - name: test
                     size: "{{ volume_size }}"
 
-        - name: Get the partition table type on disk removed from the VG
+        - name: Get the partition table type on disk removed from the VG - 2
           command: blkid -p -ovalue -s PTTYPE /dev/{{ unused_disks[0] }}
           register: storage_test_removed_pttype
           changed_when: false
           failed_when: not storage_test_removed_pttype.rc in [0, 2]
 
-        - name: Verify that removing the PV from the VG also removed the partition table
+        - name: Verify that removing the PV from the VG also removed the partition table - 2
           assert:
             that: storage_test_removed_pttype.stdout == ''
 
-        - name: Get UUID of the 'foo' volume group
+        - name: Get UUID of the 'foo' volume group - 8
           command: vgs --noheading -o vg_uuid foo
           changed_when: false
           register: storage_test_members_vg_uuid_after
 
-        - name: Make sure the VG UUID didn't change (VG wasn't removed)
+        - name: Make sure the VG UUID didn't change (VG wasn't removed) - 8
           assert:
             that: storage_test_members_vg_uuid.stdout ==
               storage_test_members_vg_uuid_after.stdout
@@ -318,5 +318,5 @@
                 disks: "{{ unused_disks }}"
                 state: absent
 
-        - name: Verify role results
+        - name: Verify role results - 9
           include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_pool_pv_grow.yml
+++ b/tests/tests_lvm_pool_pv_grow.yml
@@ -73,7 +73,7 @@
                   - name: test1
                     size: 100%
 
-        - name: Verify role results
+        - name: Verify role results - 2
           include_tasks: verify-role-results.yml
 
       always:
@@ -88,5 +88,5 @@
                 volumes:
                   - name: test1
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_pool_shared.yml
+++ b/tests/tests_lvm_pool_shared.yml
@@ -152,7 +152,7 @@
                     fs_type: gfs2
                     fs_create_options: -j 2 -t rhel9-1node:myfs
 
-        - name: Verify role results
+        - name: Verify role results - 2
           include_tasks: verify-role-results.yml
 
         - name: >-
@@ -172,7 +172,7 @@
                     size: "{{ volume1_size }}"
                     mount_point: "{{ mount_location1 }}"
 
-        - name: Verify role results
+        - name: Verify role results - 3
           include_tasks: verify-role-results.yml
 
       always:

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -59,7 +59,7 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify results
+    - name: Verify results - 2
       include_tasks: verify-role-results.yml
 
     - name: >-
@@ -86,7 +86,7 @@
                   fs_create_options: -Fb 512
                   mount_point: "{{ mount_location }}"
 
-    - name: Remove the volume group created above
+    - name: Remove the volume group created above - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -112,7 +112,7 @@
                 size: "{{ volume1_size }}"
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify results
+    - name: Verify results - 3
       include_tasks: verify-role-results.yml
 
     - name: Test for correct handling resize large size
@@ -133,7 +133,7 @@
                   size: "{{ too_large_size }}"
                   mount_point: "{{ mount_location }}"
 
-    - name: Remove the volume group created above
+    - name: Remove the volume group created above - 3
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -157,7 +157,7 @@
                 fs_type: ext4
                 mount_point: "{{ mount_location }}"
 
-    - name: Verify results
+    - name: Verify results - 4
       include_tasks: verify-role-results.yml
 
     - name: Test setting up disk volume will remove the partition create above
@@ -173,7 +173,7 @@
             mount_point: "{{ mount_location }}"
             mount_options: rw,noatime,defaults
 
-    - name: Verify results
+    - name: Verify results - 5
       include_tasks: verify-role-results.yml
       vars:
         __storage_verify_mount_options: true
@@ -219,7 +219,7 @@
               fs_type: swap
               mount_point: "{{ mount_location }}"
 
-    - name: Remove the disk volume created above
+    - name: Remove the disk volume created above - 2
       include_role:
         name: linux-system-roles.storage
       vars:

--- a/tests/tests_missing_volume_type_in_pool.yml
+++ b/tests/tests_missing_volume_type_in_pool.yml
@@ -60,12 +60,12 @@
                 mount_point: "{{ mount_location }}"
                 state: absent
 
-    - name: Ensure the inherited type is reflected in blivet module output
+    - name: Ensure the inherited type is reflected in blivet module output - 2
       assert:
         that: blivet_output.pools[0].volumes[0].type == "partition"
         msg: "Incorrect type assigned to un-typed volume in partition pool"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -82,10 +82,10 @@
                 mount_point: "{{ mount_location }}"
                 state: absent
 
-    - name: Ensure the inherited type is reflected in blivet module output
+    - name: Ensure the inherited type is reflected in blivet module output - 3
       assert:
         that: blivet_output.pools[0].volumes[0].type == "partition"
         msg: "Incorrect type assigned to un-typed volume in partition pool"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -74,10 +74,10 @@
               - name: lv1
                 size: "{{ volume1_size }}"
                 mount_point: "{{ mount_location1 }}"
-              - name: Lv2
+              - name: Lv2 - 2
                 size: "{{ volume2_size }}"
                 mount_point: "{{ mount_location2 }}"
-              - name: Lv3
+              - name: Lv3 - 2
                 size: "{{ volume3_size }}"
                 mount_point: "{{ mount_location3 }}"
 
@@ -90,7 +90,7 @@
               blivet_output.pools[0].raid_metadata_version == '1.0'
         msg: "Failure to preserve RAID settings for preexisting pool."
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove the pool created above
@@ -110,14 +110,14 @@
               - name: lv1
                 size: "{{ volume1_size }}"
                 mount_point: "{{ mount_location1 }}"
-              - name: Lv2
+              - name: Lv2 - 3
                 size: "{{ volume2_size }}"
                 mount_point: "{{ mount_location2 }}"
-              - name: Lv3
+              - name: Lv3 - 3
                 size: "{{ volume3_size }}"
                 mount_point: "{{ mount_location3 }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID0 device
@@ -134,10 +134,10 @@
             raid_chunk_size: "1024 KiB"
             state: present
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
-    - name: Remove the pool created above
+    - name: Remove the pool created above - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -151,5 +151,5 @@
             raid_chunk_size: "1024 KiB"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -65,7 +65,7 @@
               blivet_output.volumes[0].raid_metadata_version == '1.0'
         msg: "Failure to preserve RAID settings for preexisting volume."
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above
@@ -83,10 +83,10 @@
             mount_point: "{{ mount_location }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
-    - name: Create a RAID0 device mounted on "{{ mount_location }}"
+    - name: Create again a RAID0 device mounted on "{{ mount_location }}"
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -101,10 +101,10 @@
             mount_point: "{{ mount_location }}"
             state: present
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
-    - name: Remove the disk device created above
+    - name: Remove the disk device created above - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -119,5 +119,5 @@
             mount_point: "{{ mount_location }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml

--- a/tests/tests_remove_mount.yml
+++ b/tests/tests_remove_mount.yml
@@ -56,7 +56,7 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -71,7 +71,7 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -87,5 +87,5 @@
                 size: "{{ volume_size }}"
                 mount_point: "{{ mount_location_after }}"
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -55,5 +55,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -75,7 +75,7 @@
                     size: "{{ volume_size_after }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 2
           include_tasks: verify-role-results.yml
 
         - name: Change volume size to {{ volume_size_before }}
@@ -92,7 +92,7 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 3
           include_tasks: verify-role-results.yml
 
         - name: Test for correct handling of too-large volume size
@@ -128,7 +128,7 @@
                         size: "{{ disk_size }}"
                         mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 4
           include_tasks: verify-role-results.yml
 
         - name: Test for correct handling of acceptable size difference (slightly bigger than max)
@@ -148,7 +148,7 @@
                         size: "{{ acc_large_size }}"
                         mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 5
           include_tasks: verify-role-results.yml
 
         - name: Test for correct handling of invalid size specification
@@ -167,7 +167,7 @@
                       size: "{{ invalid_size1 }}"
                       mount_point: "{{ mount_location }}"
 
-        - name: Test for correct handling of invalid size specification
+        - name: Test for correct handling of invalid size specification - 2
           include_tasks: verify-role-failed.yml
           vars:
             __storage_failed_regex: invalid.+size
@@ -197,7 +197,7 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 6
       include_tasks: verify-role-results.yml
 
     # For ext3 FS
@@ -220,7 +220,7 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 7
           include_tasks: verify-role-results.yml
 
         - name: Change volume size to {{ volume_size_after }}
@@ -237,10 +237,10 @@
                     size: "{{ volume_size_after }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 8
           include_tasks: verify-role-results.yml
 
-        - name: Change volume size to {{ volume_size_before }}
+        - name: Change volume size to before size {{ volume_size_before }}
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -254,11 +254,11 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 9
           include_tasks: verify-role-results.yml
 
       always:
-        - name: Clean up
+        - name: Clean up - 2
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -271,7 +271,7 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 10
       include_tasks: verify-role-results.yml
 
     # For ext2 FS
@@ -294,10 +294,10 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 11
           include_tasks: verify-role-results.yml
 
-        - name: Change volume size to {{ volume_size_after }}
+        - name: Change volume size to after size {{ volume_size_after }}
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -311,10 +311,10 @@
                     size: "{{ volume_size_after }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 12
           include_tasks: verify-role-results.yml
 
-        - name: Change volume size to {{ volume_size_before }}
+        - name: Change again volume size to before size {{ volume_size_before }}
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -328,11 +328,11 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-        - name: Verify role results
+        - name: Verify role results - 13
           include_tasks: verify-role-results.yml
 
       always:
-        - name: Clean up
+        - name: Clean up - 3
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -345,7 +345,7 @@
                     size: "{{ volume_size_before }}"
                     mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
+    - name: Verify role results - 14
       include_tasks: verify-role-results.yml
 
     - name: Gather package facts
@@ -375,153 +375,100 @@
     # For ext4 FS -- online resize
     - name: Test ext4 online resize
       block:
-      - name: Run test on supported platforms
-        when: ((is_fedora and blivet_pkg_version is version("3.7.1-3", ">=")) or
-              (is_rhel8 and blivet_pkg_version is version("3.6.0-6", ">=")) or
-              (is_rhel9 and blivet_pkg_version is version("3.6.0-8", ">=")) or
-              is_rhel10)
-        block:
-          - name: >-
-              Create one LVM logical volume under one volume group with size
-              {{ volume_size_before }}
-            include_role:
-              name: linux-system-roles.storage
-            vars:
-              storage_pools:
-                - name: foo
-                  disks: "{{ unused_disks }}"
-                  type: lvm
-                  volumes:
-                    - name: test1
-                      fs_type: ext4
-                      size: "{{ volume_size_before }}"
-                      mount_point: "{{ mount_location }}"
-
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
-
-          - name: Change volume_size to {{ volume_size_after }}
-            include_role:
-              name: linux-system-roles.storage
-            vars:
-              storage_pools:
-                - name: foo
-                  type: lvm
-                  disks: "{{ unused_disks }}"
-                  volumes:
-                    - name: test1
-                      fs_type: ext4
-                      size: "{{ volume_size_after }}"
-                      mount_point: "{{ mount_location }}"
-
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
-
-          - name: Test for correct handling of offline resize in safe mode
-            include_tasks: verify-role-failed.yml
-            vars:
-              __storage_failed_regex: must be unmounted to be resized in safe mode
-              __storage_failed_msg: >-
-                Unexpected behavior w/ resize in safe mode
-              __storage_failed_params:
-                storage_safe_mode: true
+        - name: Run test on supported platforms
+          when: ((is_fedora and blivet_pkg_version is version("3.7.1-3", ">=")) or
+                (is_rhel8 and blivet_pkg_version is version("3.6.0-6", ">=")) or
+                (is_rhel9 and blivet_pkg_version is version("3.6.0-8", ">=")) or
+                is_rhel10)
+          block:
+            - name: >-
+                Create one LVM logical volume under one volume group with size
+                {{ volume_size_before }}
+              include_role:
+                name: linux-system-roles.storage
+              vars:
                 storage_pools:
                   - name: foo
                     disks: "{{ unused_disks }}"
+                    type: lvm
                     volumes:
                       - name: test1
                         fs_type: ext4
                         size: "{{ volume_size_before }}"
                         mount_point: "{{ mount_location }}"
 
-      always:
-        - name: Clean up
-          include_role:
-            name: linux-system-roles.storage
-          vars:
-            storage_pools:
-              - name: foo
-                disks: "{{ unused_disks }}"
-                state: absent
-                volumes:
-                  - name: test1
-                    size: "{{ volume_size_before }}"
-                    mount_point: "{{ mount_location }}"
+            - name: Verify role results - 15
+              include_tasks: verify-role-results.yml
 
-        - name: Verify role results
-          include_tasks: verify-role-results.yml
+            - name: Change volume_size to after size {{ volume_size_after }}
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    type: lvm
+                    disks: "{{ unused_disks }}"
+                    volumes:
+                      - name: test1
+                        fs_type: ext4
+                        size: "{{ volume_size_after }}"
+                        mount_point: "{{ mount_location }}"
+
+            - name: Verify role results - 16
+              include_tasks: verify-role-results.yml
+
+            - name: Test for correct handling of offline resize in safe mode
+              include_tasks: verify-role-failed.yml
+              vars:
+                __storage_failed_regex: must be unmounted to be resized in safe mode
+                __storage_failed_msg: >-
+                  Unexpected behavior w/ resize in safe mode
+                __storage_failed_params:
+                  storage_safe_mode: true
+                  storage_pools:
+                    - name: foo
+                      disks: "{{ unused_disks }}"
+                      volumes:
+                        - name: test1
+                          fs_type: ext4
+                          size: "{{ volume_size_before }}"
+                          mount_point: "{{ mount_location }}"
+
+          always:
+            - name: Clean up - 4
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    state: absent
+                    volumes:
+                      - name: test1
+                        size: "{{ volume_size_before }}"
+                        mount_point: "{{ mount_location }}"
+
+            - name: Verify role results - 17
+              include_tasks: verify-role-results.yml
 
       # For XFS
 
     - name: Test xfs
       block:
-      - name: Run test on supported platforms
-        when: ((is_fedora and blivet_pkg_version is version("3.12.1-3", ">=")) or
-              (is_rhel8 and blivet_pkg_version is version("3.4.0-1", ">=")) or
-              is_rhel9 or is_rhel10)
-        block:
-          - name: >-
-              Create a LVM logical volume with for XFS size
-              {{ volume_size_before }}
-            include_role:
-              name: linux-system-roles.storage
-            vars:
-              storage_pools:
-                - name: foo
-                  type: lvm
-                  disks: "{{ unused_disks }}"
-                  volumes:
-                    - name: test1
-                      fs_type: xfs
-                      size: "{{ volume_size_before }}"
-                      mount_point: "{{ mount_location }}"
-
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
-
-          - name: Change volume size to {{ volume_size_after }}
-            include_role:
-              name: linux-system-roles.storage
-            vars:
-              storage_pools:
-                - name: foo
-                  type: lvm
-                  disks: "{{ unused_disks }}"
-                  volumes:
-                    - name: test1
-                      fs_type: xfs
-                      size: "{{ volume_size_after }}"
-                      mount_point: "{{ mount_location }}"
-
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
-
-          - name: Repeat for idempotency test
-            include_role:
-              name: linux-system-roles.storage
-            vars:
-              storage_pools:
-                - name: foo
-                  type: lvm
-                  disks: "{{ unused_disks }}"
-                  volumes:
-                    - name: test1
-                      fs_type: xfs
-                      size: "{{ volume_size_after }}"
-                      mount_point: "{{ mount_location }}"
-
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
-
-          - name: Test for correct handling of shrinking (not supported by XFS)
-            include_tasks: verify-role-failed.yml
-            vars:
-              __storage_failed_regex: volume.+cannot be resized.+
-              __storage_failed_msg: >-
-                Unexpected behavior w/ invalid volume size
-              __storage_failed_params:
+        - name: Run test on supported platforms - 2
+          when: ((is_fedora and blivet_pkg_version is version("3.12.1-3", ">=")) or
+                (is_rhel8 and blivet_pkg_version is version("3.4.0-1", ">=")) or
+                is_rhel9 or is_rhel10)
+          block:
+            - name: >-
+                Create a LVM logical volume with for XFS size
+                {{ volume_size_before }}
+              include_role:
+                name: linux-system-roles.storage
+              vars:
                 storage_pools:
                   - name: foo
+                    type: lvm
                     disks: "{{ unused_disks }}"
                     volumes:
                       - name: test1
@@ -529,39 +476,92 @@
                         size: "{{ volume_size_before }}"
                         mount_point: "{{ mount_location }}"
 
-          - name: Test for correct handling of acceptable size difference (slightly smaller than min)
-            block:
-              - name: >-
-                  Try to resize LVM volume size to disk size - 1.5 % (less than 2 % than
-                  minimum size should be tolerated)
-                include_role:
-                  name: linux-system-roles.storage
-                vars:
+            - name: Verify role results - 18
+              include_tasks: verify-role-results.yml
+
+            - name: Change again volume size to after size {{ volume_size_after }}
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    type: lvm
+                    disks: "{{ unused_disks }}"
+                    volumes:
+                      - name: test1
+                        fs_type: xfs
+                        size: "{{ volume_size_after }}"
+                        mount_point: "{{ mount_location }}"
+
+            - name: Verify role results - 19
+              include_tasks: verify-role-results.yml
+
+            - name: Repeat for idempotency test
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    type: lvm
+                    disks: "{{ unused_disks }}"
+                    volumes:
+                      - name: test1
+                        fs_type: xfs
+                        size: "{{ volume_size_after }}"
+                        mount_point: "{{ mount_location }}"
+
+            - name: Verify role results - 20
+              include_tasks: verify-role-results.yml
+
+            - name: Test for correct handling of shrinking (not supported by XFS)
+              include_tasks: verify-role-failed.yml
+              vars:
+                __storage_failed_regex: volume.+cannot be resized.+
+                __storage_failed_msg: >-
+                  Unexpected behavior w/ invalid volume size
+                __storage_failed_params:
                   storage_pools:
                     - name: foo
                       disks: "{{ unused_disks }}"
                       volumes:
                         - name: test1
                           fs_type: xfs
-                          size: "{{ acc_small_size }}"
+                          size: "{{ volume_size_before }}"
                           mount_point: "{{ mount_location }}"
 
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
+            - name: Test for correct handling of acceptable size difference (slightly smaller than min)
+              block:
+                - name: >-
+                    Try to resize LVM volume size to disk size - 1.5 % (less than 2 % than
+                    minimum size should be tolerated)
+                  include_role:
+                    name: linux-system-roles.storage
+                  vars:
+                    storage_pools:
+                      - name: foo
+                        disks: "{{ unused_disks }}"
+                        volumes:
+                          - name: test1
+                            fs_type: xfs
+                            size: "{{ acc_small_size }}"
+                            mount_point: "{{ mount_location }}"
 
-        always:
-          - name: Clean up
-            include_role:
-              name: linux-system-roles.storage
-            vars:
-              storage_pools:
-                - name: foo
-                  disks: "{{ unused_disks }}"
-                  state: absent
-                  volumes:
-                    - name: test1
-                      size: "{{ volume_size_before }}"
-                      mount_point: "{{ mount_location }}"
+            - name: Verify role results - 21
+              include_tasks: verify-role-results.yml
 
-          - name: Verify role results
-            include_tasks: verify-role-results.yml
+          always:
+            - name: Clean up - 5
+              include_role:
+                name: linux-system-roles.storage
+              vars:
+                storage_pools:
+                  - name: foo
+                    disks: "{{ unused_disks }}"
+                    state: absent
+                    volumes:
+                      - name: test1
+                        size: "{{ volume_size_before }}"
+                        mount_point: "{{ mount_location }}"
+
+            - name: Verify role results - 22
+              include_tasks: verify-role-results.yml

--- a/tests/tests_safe_mode_check.yml
+++ b/tests/tests_safe_mode_check.yml
@@ -52,7 +52,7 @@
           command: parted -s /dev/{{ unused_disks[0] }} mklabel gpt
           changed_when: false
 
-        - name: Create nilfs2 partition (1/2)
+        - name: Create nilfs2 partition (1/2) - 2
           command: parted -s /dev/{{ unused_disks[0] }} mkpart primary 0% 100%
           changed_when: false
 

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -97,7 +97,7 @@
                         size: "{{ volume_size }}"
                         mount_point: "{{ mount_location }}"
 
-            - name: Verify role results
+            - name: Verify role results - 2
               include_tasks: verify-role-results.yml
 
             - name: Add second filesystem to the pool
@@ -116,7 +116,7 @@
                         size: "{{ volume_size }}"
                         mount_point: "{{ mount_location_2 }}"
 
-            - name: Verify role results
+            - name: Verify role results - 3
               include_tasks: verify-role-results.yml
 
           always:
@@ -139,7 +139,7 @@
                         mount_point: "{{ mount_location_2 }}"
                         state: absent
 
-        - name: Verify role results
+        - name: Verify role results - 4
           include_tasks: verify-role-results.yml
 
         - name: Run test only if blivet supports this functionality
@@ -164,10 +164,10 @@
                             size: "{{ volume_size }}"
                             mount_point: "{{ mount_location }}"
 
-                - name: Verify role results
+                - name: Verify role results - 5
                   include_tasks: verify-role-results.yml
 
-                - name: Repeat the previous invocation to verify idempotence
+                - name: Repeat the previous invocation to verify idempotence - 2
                   include_role:
                     name: linux-system-roles.storage
                   vars:
@@ -182,11 +182,11 @@
                             size: "{{ volume_size }}"
                             mount_point: "{{ mount_location }}"
 
-                - name: Verify role results
+                - name: Verify role results - 6
                   include_tasks: verify-role-results.yml
 
               always:
-                - name: Clean up
+                - name: Clean up - 2
                   include_role:
                     name: linux-system-roles.storage
                   vars:
@@ -201,7 +201,7 @@
                             mount_point: "{{ mount_location }}"
                             state: absent
 
-            - name: Verify role results
+            - name: Verify role results - 7
               include_tasks: verify-role-results.yml
 
             - name: Test one disk pool
@@ -215,7 +215,7 @@
                         disks: "{{ unused_disks[0] }}"
                         type: stratis
 
-                - name: Verify role results
+                - name: Verify role results - 8
                   include_tasks: verify-role-results.yml
 
                 - name: Add the second disk to the pool
@@ -227,11 +227,11 @@
                         disks: "{{ [unused_disks[0], unused_disks[1]] }}"
                         type: stratis
 
-                - name: Verify role results
+                - name: Verify role results - 9
                   include_tasks: verify-role-results.yml
 
               always:
-                - name: Clean up
+                - name: Clean up - 3
                   include_role:
                     name: linux-system-roles.storage
                   vars:
@@ -246,7 +246,7 @@
                             mount_point: "{{ mount_location }}"
                             state: absent
 
-            - name: Verify role results
+            - name: Verify role results - 10
               include_tasks: verify-role-results.yml
 
             - name: Setup Tang server on localhost for testing
@@ -272,11 +272,11 @@
                         encryption_clevis_pin: tang
                         encryption_tang_url: localhost:7500
 
-                - name: Verify role results
+                - name: Verify role results - 11
                   include_tasks: verify-role-results.yml
 
               always:
-                - name: Clean up
+                - name: Clean up - 4
                   include_role:
                     name: linux-system-roles.storage
                   vars:
@@ -286,5 +286,5 @@
                         type: stratis
                         state: absent
 
-            - name: Verify role results
+            - name: Verify role results - 12
               include_tasks: verify-role-results.yml

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -70,7 +70,7 @@
             fs_type: ext3
             disks: "{{ [__non_swap_disk] }}"
 
-    - name: Verify results
+    - name: Verify results - 2
       include_tasks: verify-role-results.yml
 
     - name: Change the disk device file system type from swap to ext3
@@ -84,7 +84,7 @@
             fs_type: ext3
             disks: "{{ [__swap_disk] }}"
 
-    - name: Verify results
+    - name: Verify results - 3
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
@@ -98,7 +98,7 @@
             fs_type: ext3
             disks: "{{ [__swap_disk] }}"
 
-    - name: Verify results
+    - name: Verify results - 4
       include_tasks: verify-role-results.yml
 
     - name: Change it back to swap
@@ -111,10 +111,10 @@
             disks: "{{ [__swap_disk] }}"
             fs_type: swap
 
-    - name: Verify results
+    - name: Verify results - 5
       include_tasks: verify-role-results.yml
 
-    - name: Repeat the previous invocation to verify idempotence
+    - name: Repeat the previous invocation to verify idempotence - 2
       include_role:
         name: linux-system-roles.storage
       vars:
@@ -124,7 +124,7 @@
             disks: "{{ [__swap_disk] }}"
             fs_type: swap
 
-    - name: Verify results
+    - name: Verify results - 6
       include_tasks: verify-role-results.yml
 
     - name: Clean up
@@ -143,5 +143,5 @@
             mount_point: none
             state: absent
 
-    - name: Verify results
+    - name: Verify results - 7
       include_tasks: verify-role-results.yml

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -54,7 +54,7 @@
             disks: "{{ unused_disks }}"
             fs_label: relabel
 
-    - name: Verify role results
+    - name: Verify role results - 2
       include_tasks: verify-role-results.yml
 
     - name: Run relabel again to verify idempotence
@@ -74,7 +74,7 @@
         that: not blivet_output.changed
         msg: "Volume relabeling is not idempotent."
 
-    - name: Verify role results
+    - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Relabel without explicitly setting the label
@@ -93,7 +93,7 @@
         that: not blivet_output.changed
         msg: "Volume relabeling doesn't preserve existing label."
 
-    - name: Verify role results
+    - name: Verify role results - 4
       include_tasks: verify-role-results.yml
 
     - name: Remove label
@@ -108,7 +108,7 @@
             disks: "{{ unused_disks }}"
             fs_label: ""
 
-    - name: Verify role results
+    - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
     - name: Format the device to LVMPV which doesn't support labels
@@ -142,5 +142,5 @@
             disks: "{{ unused_disks }}"
             state: absent
 
-    - name: Verify role results
+    - name: Verify role results - 6
       include_tasks: verify-role-results.yml

--- a/tests/verify-pool-member-vdo.yml
+++ b/tests/verify-pool-member-vdo.yml
@@ -32,13 +32,13 @@
       register: storage_test_vdo_status
       changed_when: false
 
-    - name: Check if VDO deduplication is off
+    - name: Check if VDO deduplication is off - 2
       assert:
         that: storage_test_vdo_status.stdout | trim != "enabled"
         msg: VDO compression is on but it should not
       when: not storage_test_vdo_volume.compression
 
-    - name: Check if VDO deduplication is on
+    - name: Check if VDO deduplication is on - 2
       assert:
         that: storage_test_vdo_status.stdout | trim == "enabled"
         msg: VDO compression is off but it should not

--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -7,7 +7,7 @@
         storage_pools_global: "{{ storage_pools | d([]) }}"
         storage_volumes_global: "{{ storage_volumes | d([]) }}"
 
-    - name: Verify role raises correct error
+    - name: Verify role raises correct error - 2
       include_role:
         name: linux-system-roles.storage
       vars:


### PR DESCRIPTION
the new ansible-lint wants all task names to be unique, and
is more strict about indentation

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor test playbooks to satisfy newer ansible-lint requirements by ensuring all task names are unique and by correcting indentation

Enhancements:
- Append numeric suffixes to duplicate task names in test playbooks to ensure uniqueness
- Adjust indentation of nested blocks and tasks across test files to comply with stricter ansible-lint rules