### PR TITLE
docs(changelog): version 1.18.18 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[1.18.18] - 2025-07-09
+--------------------
+
+### Other Changes
+
+- refactor: make task names unique; fix indentation (#542)
+- refactor: correct volume names changed by previous fix (#543)
+
 [1.18.17] - 2025-06-16
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.18.18

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation for the 1.18.18 release

Documentation:
- Add changelog entry for version 1.18.18 with refactors for unique task names and corrected volume names
- Update README HTML to reference version 1.18.18