### PR TITLE
fix: the encryption_key parameter should not be marked as no_log

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -40,7 +40,7 @@ options:
                 description: encryption_cipher
                 type: str
             encryption_key:
-                description: encryption_key
+                description: encryption_key file, not the actual key
                 type: str
             encryption_key_size:
                 description: encryption_key_size
@@ -105,7 +105,7 @@ options:
                         description: encryption_cipher
                         type: str
                     encryption_key:
-                        description: encryption_key
+                        description: encryption_key file, not the actual key
                         type: str
                     encryption_key_size:
                         description: encryption_key_size
@@ -210,7 +210,7 @@ options:
                 description: encryption_cipher
                 type: str
             encryption_key:
-                description: encryption_key
+                description: encryption_key file, not the actual key
                 type: str
             encryption_key_size:
                 description: encryption_key_size
@@ -2331,9 +2331,16 @@ def generate_module_doc(module_args, input="", indent=4):
 
 def run_module():
     # available arguments/parameters that a user can pass
+    # NOTE: The encryption_key parameter is the name of the key file, not the
+    # actual key.  This is confusing because it is also referred to as "password"
+    # in the crypts dict.  Since this is just a filename, it does not need to
+    # be marked as no_log - however, since the name is "encryption_key", Ansible
+    # thinks that it should be marked as no_log, so we have to explicitly mark
+    # it as no_log=False for ansible-test.
+    # see https://github.com/linux-system-roles/storage/pull/546
     common_volume_opts = dict(encryption=dict(type='bool'),
                               encryption_cipher=dict(type='str'),
-                              encryption_key=dict(type='str', no_log=True),
+                              encryption_key=dict(type='str', no_log=False),
                               encryption_key_size=dict(type='int'),
                               encryption_luks_version=dict(type='str'),
                               encryption_password=dict(type='str', no_log=True),
@@ -2377,7 +2384,7 @@ def run_module():
                    options=dict(disks=dict(type='list', elements='str', default=list()),
                                 encryption=dict(type='bool'),
                                 encryption_cipher=dict(type='str'),
-                                encryption_key=dict(type='str', no_log=True),
+                                encryption_key=dict(type='str', no_log=False),
                                 encryption_key_size=dict(type='int'),
                                 encryption_luks_version=dict(type='str'),
                                 encryption_password=dict(type='str', no_log=True),


### PR DESCRIPTION
Cause: The encryption_key parameter to the blivet module was marked as
no_log.  This causes the output value from the module to be replaced with the
string `VALUE_SPECIFIED_IN_NO_LOG_PARAMETER` which is then used as the value
for the key file in crypttab and in tests.

Consequence: Disk encryption using a key file does not work as the specified
key file is not used.

Fix: The encryption_key parameter does not need to be marked no_log because
it is just the name of the file, not the actual key contents.

Result: Disk encryption works, and the actual key file is used in crypttab
and elsewhere.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Unmasked the encryption_key parameter to prevent it from being replaced with a placeholder value and ensure the real key file is used in crypttab and tests