### PR TITLE
test: test luks encryption key

### DIFF
--- a/tests/test-verify-volume-encryption.yml
+++ b/tests/test-verify-volume-encryption.yml
@@ -110,8 +110,8 @@
       map('regex_search', '^' + storage_test_volume._device |
           basename + ' .*$') |
       select('string') | list }}"
-    _storage_test_expected_crypttab_key_file: "{{
-      storage_test_volume.encryption_key or '-' }}"
+    _storage_test_expected_crypttab_key_file: "{{ __test_encryption_key |
+      d(storage_test_volume.encryption_key or '-') }}"
 
 - name: Check for /etc/crypttab entry
   assert:

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -344,6 +344,9 @@
 
         - name: Verify role results - 6
           include_tasks: verify-role-results.yml
+          vars:
+            __test_encryption_key: "{{ storage_test_key_file.path }}"
+
       always:
         - name: Remove the key file
           file:


### PR DESCRIPTION
The storage_test_volume.encryption_key comes from the same variable that
is used to write the key to the crypttab - so change the test to test
against the original value passed in to the role.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Improve LUKS encryption tests to verify against the original key and expand coverage across disk interfaces

Tests:
- Update encryption assertion to use __test_encryption_key variable for crypttab verification
- Add auto-generated playbooks for NVMe and SCSI variants of mixed and mixed_2 LUKS tests