### PR TITLE
tests: Fix verification for LVM pool on top encrypted MD RAID

### DIFF
--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -58,6 +58,7 @@
     - storage_test_pool.type == 'lvm'
     - not storage_test_pool.raid_level is none
     - storage_test_pool.raid_level | length > 0
+    - not storage_test_pool.encryption
 
 - name: Check the type of each PV
   assert:

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -284,6 +284,43 @@
     - name: Verify role results - 11
       include_tasks: verify-role-results.yml
 
+    - name: Create encrypted RAID1 LVM device
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            type: lvm
+            disks: "{{ unused_disks }}"
+            raid_level: raid1
+            encryption: true
+            encryption_password: yabbadabbadoo
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+
+    - name: Verify role results - 12
+      include_tasks: verify-role-results.yml
+
+    - name: Remove the device created above - 5
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: vg1
+            type: lvm
+            state: absent
+            disks: "{{ unused_disks }}"
+            raid_level: raid1
+            encryption: true
+            encryption_password: yabbadabbadoo
+            volumes:
+              - name: lv1
+                size: "{{ volume1_size }}"
+
+    - name: Verify role results - 13
+      include_tasks: verify-role-results.yml
+
     - name: Run test on supported platforms
       when: ((is_fedora and blivet_pkg_version is version("3.7.1-2", ">=")) or
              (is_rhel8 and blivet_pkg_version is version("3.6.0-5", ">=")) or
@@ -307,10 +344,10 @@
                     raid_level: raid0
                     raid_stripe_size: "256 KiB"
 
-        - name: Verify role results - 12
+        - name: Verify role results - 14
           include_tasks: verify-role-results.yml
 
-        - name: Remove the device created above - 5
+        - name: Remove the device created above - 6
           include_role:
             name: linux-system-roles.storage
           vars:
@@ -326,5 +363,5 @@
                     raid_level: raid0
                     raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-        - name: Verify role results - 13
+        - name: Verify role results - 15
           include_tasks: verify-role-results.yml

--- a/tests/verify-pool-md.yml
+++ b/tests/verify-pool-md.yml
@@ -6,7 +6,7 @@
     - storage_test_pool.state != "absent"
   block:
     - name: Get information about RAID
-      command: mdadm --detail {{ _storage_test_pool_pvs[0] }}
+      command: mdadm --detail /dev/md/{{ storage_test_pool.name }}-1
       register: storage_test_mdadm
       changed_when: false
 


### PR DESCRIPTION
Resolves: RHEL-95719

## Summary by Sourcery

Extend test suite to cover encrypted RAID1 LVM pools and correct related verifications

Bug Fixes:
- fix mdadm detail command to reference /dev/md/<pool>-1
- skip pool-member assertions for encrypted LVM pools

Tests:
- add create, verify, and remove tests for encrypted RAID1 LVM pools
- renumber verify-role-results tasks after inserting encrypted pool tests
- update verify-pool-md to use consistent md device naming
- exclude encrypted pools in test-verify-pool-members assertions