### PR TITLE
test: fix error string checking for raid failures

### DIFF
--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -44,7 +44,8 @@
 
     - name: Verify correct exception or error message
       assert:
-        that: msg_msg is search(__storage_failed_exception) or
+        that: result_msg is search(__storage_failed_exception) or
+          msg_msg is search(__storage_failed_exception) or
           exception is search(__storage_failed_exception) or
           msg_stdout is search(__storage_failed_exception) or
           msg_stderr is search(__storage_failed_exception) or
@@ -52,6 +53,7 @@
           stderr is search(__storage_failed_exception)
       when: __storage_failed_exception is defined
       vars:
+        result_msg: "{{ ansible_failed_result.msg | d('') }}"
         msg_msg: "{{ ansible_failed_result.msg.msg | d('') }}"
         exception: "{{ ansible_failed_result.msg.exception | d('') }}"
         msg_stdout: "{{ ansible_failed_result.msg.module_stdout | d('') }}"


### PR DESCRIPTION
Recent changes to error handling changed the way the error message
is reported on ansible 2.9

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update failed-role verification tests to handle changed error message reporting in Ansible 2.9

Tests:
- Add result_msg variable to capture top-level error message from ansible_failed_result
- Include result_msg in the assertion chain for matching the expected exception string