### PR TITLE
fix: Allow running on systems without /etc/fstab present

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -2186,6 +2186,9 @@ class FSTab(object):
         if self._entries:
             self.reset()
 
+        if not os.path.exists('/etc/fstab'):
+            return
+
         with open('/etc/fstab') as f:
             for line in f.readlines():
                 if line.lstrip().startswith("#"):


### PR DESCRIPTION
When /etc/fstab is not present, we'll simply skip parsing it.

Fixes: #557
Resolves: RHEL-115033