### PR TITLE
docs(changelog): version 1.19.1 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+[1.19.1] - 2025-11-17
+--------------------
+
+### Bug Fixes
+
+- fix: cannot use community-general version 12 - no py27 and py36 support (#571)
+
+### Other Changes
+
+- ci: bump github/codeql-action from 3 to 4 (#566)
+- ci: bump actions/upload-artifact from 4 to 5 (#567)
+- ci: use versioned upload-artifact instead of master; bump codeql-action to v4; bump upload-artifact to v5 (#568)
+- ci: bump tox-lsr to 3.13.0 (#569)
+- ci: bump tox-lsr to 3.14.0 - this moves standard-inventory-qcow2 to tox-lsr (#570)
+
 [1.19.0] - 2025-10-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.19.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.19.1 by updating the changelog and README HTML, including a bug fix and CI dependency bumps.

Bug Fixes:
- Fix community-general version 12 incompatibility by restoring py27 and py36 support

CI:
- Bump github/codeql-action from v3 to v4
- Bump actions/upload-artifact from v4 to v5 and switch to versioned release
- Bump tox-lsr to v3.13.0 and v3.14.0

Documentation:
- Add entry for version 1.19.1 to CHANGELOG.md and update README.html