### PR TITLE
refactor: handle INJECT_FACTS_AS_VARS=false by using ansible_facts instead

### DIFF
--- a/tasks/enable_copr.yml
+++ b/tasks/enable_copr.yml
@@ -2,13 +2,13 @@
 - name: Get list of COPRs
   shell: |
     set -euo pipefail
-    {{ ansible_pkg_mgr }} repolist | \
+    {{ ansible_facts['pkg_mgr'] }} repolist | \
     grep -c `echo {{ repo.repository }} | tr / :` || true
   register: copr_present
   changed_when: false
 
 - name: Enable COPRs
   command:
-    cmd: "{{ ansible_pkg_mgr }} -y copr enable {{ repo.repository }}"
+    cmd: "{{ ansible_facts['pkg_mgr'] }} -y copr enable {{ repo.repository }}"
   when: copr_present.stdout == "0"
   changed_when: true

--- a/tests/test-verify-pool-members.yml
+++ b/tests/test-verify-pool-members.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set test variables
   set_fact:
-    _storage_test_pool_pvs_lvm: "{{ ansible_lvm.pvs | dict2items |
+    _storage_test_pool_pvs_lvm: "{{ ansible_facts['lvm'].pvs | dict2items |
       selectattr('value.vg', 'match', '^' ~ storage_test_pool.name ~ '$') |
       map(attribute='key') | list }}"
     _storage_test_expected_pv_count: "{{ 0
@@ -79,7 +79,7 @@
     scripts/does_library_support.py
     blivet.formats.lvmpv.LVMPhysicalVolume.grow_to_fill
   args:
-    executable: "{{ ansible_python.executable }}"
+    executable: "{{ ansible_facts['python'].executable }}"
   register: grow_supported
   changed_when: false
   failed_when: grow_supported.rc not in [0, 1]

--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -31,7 +31,7 @@
 
 - name: Get the size of parent/pool device
   bsize:
-    size: "{{ ansible_lvm.vgs[storage_test_pool.name].size_g + 'G' }}"
+    size: "{{ ansible_facts['lvm'].vgs[storage_test_pool.name].size_g + 'G' }}"
   register: storage_test_pool_size
   when:
     - _storage_test_volume_present | bool

--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -7,8 +7,8 @@
     mount_location: '/opt/test'
     volume_size: '5g'
     fs_type_after: "{{ 'ext3'
-      if (ansible_distribution == 'RedHat' and
-          ansible_distribution_major_version == '6')
+      if (ansible_facts['distribution'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] == '6')
       else 'ext4' }}"
   tasks:
     - name: Run the role

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -6,8 +6,8 @@
     storage_safe_mode: false
     mount_location: '/opt/test1'
     volume_size: '5g'
-    fs_after: "{{ (ansible_distribution == 'RedHat' and
-                   ansible_distribution_major_version == '6') |
+    fs_after: "{{ (ansible_facts['distribution'] == 'RedHat' and
+                   ansible_facts['distribution_major_version'] == '6') |
                   ternary('ext4', 'xfs') }}"
   tags:
     - tests::lvm

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -8,8 +8,8 @@
     mount_location: '/opt/test1'
     volume_size: '5g'
     fs_type_after: "{{ 'ext3'
-      if (ansible_distribution == 'RedHat' and
-          ansible_distribution_major_version == '6')
+      if (ansible_facts['distribution'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] == '6')
       else 'ext4' }}"
   tags:
     - tests::lvm

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -7,7 +7,7 @@
     mount_location: '/opt/test1'
     volume_group_size: '10g'
     lv_size: '10g'
-    unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
+    unused_disk_subfact: '{{ ansible_facts["devices"][unused_disks[0]] }}'
     disk_size: '{{ unused_disk_subfact.sectors | int * 512 }}'
   tags:
     - tests::lvm

--- a/tests/tests_create_thinp_then_remove.yml
+++ b/tests/tests_create_thinp_then_remove.yml
@@ -10,8 +10,8 @@
     mount_location3: '/opt/test3'
     volume1_size: '3g'
     volume2_size: '4g'
-    fs_after: "{{ (ansible_distribution == 'RedHat' and
-                   ansible_distribution_major_version == '6') |
+    fs_after: "{{ (ansible_facts['distribution'] == 'RedHat' and
+                   ansible_facts['distribution_major_version'] == '6') |
       ternary('ext4', 'xfs') }}"
 
   tasks:

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -30,10 +30,10 @@
         # create all variants like CentOS, CentOS_8.1, CentOS-8.1,
         # CentOS-8, CentOS-8.1
         # more formally:
-        # {{ ansible_distribution }}-{{ ansible_distribution_version }}
-        # {{ ansible_distribution }}-{{ ansible_distribution_major_version }}
-        # {{ ansible_distribution }}
-        # {{ ansible_os_family }}
+        # {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
+        # {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}
+        # {{ ansible_facts['distribution'] }}
+        # {{ ansible_facts['os_family'] }}
         # and the same for _ as separator.
         varfiles: "{{ [facts['distribution']] | product(separators) |
           map('join') | product(versions) | map('join') | list +

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -11,7 +11,7 @@
     invalid_disks:
       - '/non/existent/disk'
     invalid_size: 'xyz GiB'
-    unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
+    unused_disk_subfact: '{{ ansible_facts["devices"][unused_disks[0]] }}'
   tags:
     - tests::lvm
   tasks:

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -7,7 +7,7 @@
     mount_location: /opt/test1
     volume_group_size: "5g"
     volume1_size: "4g"
-    unused_disk_subfact: "{{ ansible_devices[unused_disks[0]] }}"
+    unused_disk_subfact: "{{ ansible_facts['devices'][unused_disks[0]] }}"
     too_large_size: "{{ (unused_disk_subfact.sectors | int * 1.2) * 512 }}"
   tags:
     - tests::lvm

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -10,7 +10,7 @@
     volume_size_after: '9g'
     invalid_size1: xyz GiB
     invalid_size2: none
-    unused_disk_subfact: '{{ ansible_devices[unused_disks[0]] }}'
+    unused_disk_subfact: '{{ ansible_facts["devices"][unused_disks[0]] }}'
     too_large_size: '{{ unused_disk_subfact.sectors | int * 1.2 * 512 }}'
     acc_large_size: '{{ unused_disk_subfact.sectors | int * 1.015 * 512 }}'
     acc_small_size: '{{ unused_disk_subfact.sectors | int * 0.985 * 512 }}'

--- a/tests/vars/rh_distros_vars.yml
+++ b/tests/vars/rh_distros_vars.yml
@@ -14,7 +14,7 @@ __storage_rh_distros:
 __storage_rh_distros_fedora: "{{ __storage_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__storage_is_rh_distro: "{{ ansible_distribution in __storage_rh_distros }}"
+__storage_is_rh_distro: "{{ ansible_facts['distribution'] in __storage_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__storage_is_rh_distro_fedora: "{{ ansible_distribution in __storage_rh_distros_fedora }}"
+__storage_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __storage_rh_distros_fedora }}"

--- a/tests/verify-pool-stratis.yml
+++ b/tests/verify-pool-stratis.yml
@@ -8,7 +8,7 @@
         scripts/stratis_pool_info.py
         "{{ storage_test_pool.name }}"
       args:
-        executable: "{{ ansible_python.executable }}"
+        executable: "{{ ansible_facts['python'].executable }}"
       register: storage_test_stratis_report
       changed_when: false
 

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -11,7 +11,7 @@ blivet_package_list:
   - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
-  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
+  - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"
   - vdo
 _storage_copr_support_packages:
   - dnf-plugins-core

--- a/vars/OracleLinux_9.yml
+++ b/vars/OracleLinux_9.yml
@@ -13,4 +13,4 @@ blivet_package_list:
   - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
-  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
+  - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -12,5 +12,5 @@ blivet_package_list:
   - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
-  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
+  - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"
   - vdo

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -9,7 +9,7 @@ blivet_package_list:
   - libblockdev-swap
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
-  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
+  - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"
 # additional options for mkfs when creating a disk volume (whole disk fs)
 __storage_blivet_diskvolume_mkfs_option_map:
   ext2: '-F'

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -13,4 +13,4 @@ blivet_package_list:
   - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
-  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
+  - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -13,4 +13,4 @@ blivet_package_list:
   - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
-  - "{{ 'libblockdev-s390' if ansible_architecture == 's390x' else 'libblockdev' }}"
+  - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ __storage_required_facts:
   - distribution_major_version
   - distribution_version
   - os_family
+  - pkg_mgr
 
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of
@@ -29,8 +30,8 @@ __storage_rh_distros:
 __storage_rh_distros_fedora: "{{ __storage_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__storage_is_rh_distro: "{{ ansible_distribution in __storage_rh_distros }}"
+__storage_is_rh_distro: "{{ ansible_facts['distribution'] in __storage_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__storage_is_rh_distro_fedora: "{{ ansible_distribution in __storage_rh_distros_fedora }}"
+__storage_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __storage_rh_distros_fedora }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update role variables, tasks, and tests to use the ansible_facts dictionary instead of legacy fact variables for compatibility with newer Ansible versions.

Enhancements:
- Replace direct fact variables (e.g., ansible_distribution, ansible_pkg_mgr, ansible_lvm, ansible_python, ansible_devices, ansible_architecture) with ansible_facts lookups across role vars and tasks.
- Extend required facts to include the package manager fact to support the new access pattern.

Tests:
- Update test playbooks and helper vars to reference facts via ansible_facts, aligning tests with the new fact access pattern and avoiding deprecation warnings.