### PR TITLE
fix: add vdo package for Fedora OSTree

### DIFF
--- a/.ostree/packages-runtime-Fedora.txt
+++ b/.ostree/packages-runtime-Fedora.txt
@@ -1,3 +1,4 @@
 python3-blivet
 stratisd
 stratis-cli
+vdo


### PR DESCRIPTION
Enhancement:
Fedora needs vdo package defined in var `blivet_package_list` 

Reason:
Add missing dependency for ostree

Result:
Role works on ostree based systems 

Issue Tracker Tickets (Jira or BZ if any):

## Summary by Sourcery

Enhancements:
- Extend the Fedora OSTree runtime package list to include the vdo dependency.