### PR TITLE
docs(changelog): version 1.19.3 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.19.3] - 2026-01-13
+--------------------
+
+### Bug Fixes
+
+- fix: add vdo package for Fedora OSTree (#579)
+
+### Other Changes
+
+- ci: use ANSIBLE_INJECT_FACT_VARS=false by default for testing (#580)
+
 [1.19.2] - 2026-01-06
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.19.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document the 1.19.3 release in the changelog.

Bug Fixes:
- Record the addition of the vdo package for Fedora OSTree as a bug fix in the 1.19.3 release notes.

CI:
- Note the default use of ANSIBLE_INJECT_FACT_VARS=false for testing in the 1.19.3 release notes.

Documentation:
- Add changelog section for version 1.19.3, including bug fixes and CI-related changes.