### PR TITLE
fix: Default to 100 % for volumes without size specified

### DIFF
--- a/library/blivet.py
+++ b/library/blivet.py
@@ -748,11 +748,14 @@ class BlivetVolume(BlivetBase):
 
     def _get_size(self):
         spec = self._volume['size']
+        if not spec:
+            log.debug("size for %s not specified, defaulting to 100 percent", self._volume['name'])
+            spec = "100 %"
         if isinstance(spec, str) and '%' in spec and self._blivet_pool:
             try:
                 percentage = int(spec[:-1].strip())
             except ValueError:
-                raise BlivetAnsibleError("invalid percentage '%s' size specified for volume '%s'" % (self._volume['size'], self._volume['name']))
+                raise BlivetAnsibleError("invalid percentage '%s' size specified for volume '%s'" % (spec, self._volume['name']))
 
             parent = self._blivet_pool._device
             size = parent.size * (percentage / 100.0)
@@ -760,7 +763,7 @@ class BlivetVolume(BlivetBase):
             try:
                 size = Size(spec)
             except Exception:
-                raise BlivetAnsibleError("invalid size specification for volume '%s': '%s'" % (self._volume['name'], self._volume['size']))
+                raise BlivetAnsibleError("invalid size specification for volume '%s': '%s'" % (self._volume['name'], spec))
 
         return size
 

--- a/tests/test-verify-volume-size.yml
+++ b/tests/test-verify-volume-size.yml
@@ -60,6 +60,14 @@
         storage_test_expected_size: "{{ (storage_test_pool_size.bytes *
           ((storage_test_volume.size[:-1] | int) / 100.0)) }}"
 
+- name: Unspecified size => 100 %
+  when:
+    - _storage_test_volume_present | bool
+    - storage_test_volume.type == "lvm"
+    - storage_test_volume.size | string == "0"
+  set_fact:
+      storage_test_expected_size: "{{ storage_test_pool_size.bytes }}"
+
 - name: Process thin pool sizes when applicable
   when:
     - not storage_test_volume.thin is none

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -160,3 +160,30 @@
 
     - name: Verify role results - 6
       include_tasks: verify-role-results.yml
+
+    - name: Create LV without size specified, should default to 100%
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            state: present
+            volumes:
+              - name: test1
+                mount_point: "{{ mount_location1 }}"
+
+    - name: Verify role results - 7
+      include_tasks: verify-role-results.yml
+
+    - name: Cleanup
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: foo
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - name: Verify role results - 8
+      include_tasks: verify-role-results.yml


### PR DESCRIPTION
When size is not specified in the playbook, we default to 0 which then results in ZeroDivisionError when making some size-related calculations.

Resolves: RHEL-123523

## Summary by Sourcery

Default logical volume size to 100% of the pool when unspecified and update tests accordingly.

Bug Fixes:
- Prevent ZeroDivisionError and invalid size handling by treating unspecified volume size as 100% of the parent pool.

Tests:
- Extend LVM percentage size tests and verification playbook to cover volumes created without an explicit size and their cleanup.