### PR TITLE
fix: Volume with no size is same as size 100% - fixes divide by zero error

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ variables:
   When using `compression` or `deduplication`, `size` can be set higher than actual available space,
   e.g.: 3 times the size of the volume, based on duplicity and/or compressibility of stored data.
 
+  If `size` is not specified, it will be the same as if you specified `size: 100%` - it will use
+  all available space in the pool.
+
   __NOTE__: The requested volume size may be reduced as necessary so the volume can
             fit in the available pool space, but only if the required reduction is
             not more than 2% of the requested volume size.

--- a/library/blivet.py
+++ b/library/blivet.py
@@ -1126,7 +1126,10 @@ class BlivetLVMVolume(BlivetVolume):
         return size
 
     def _trim_size(self, size, parent_device):
-
+        if size == Size(0):
+            log.info("auto-fill volume '%s': using all available free space (%s)",
+                     self._volume['name'], parent_device.free_space)
+            return parent_device.free_space
         trim_percent = (1.0 - float(parent_device.free_space / size)) * 100
         log.debug("size: %s ; %s", size, trim_percent)
 

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -160,3 +160,36 @@
 
     - name: Verify role results - 6
       include_tasks: verify-role-results.yml
+
+    - name: Create an LVM logical volume with no size specified
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: test_no_size_pool
+            disks: "{{ unused_disks }}"
+            type: lvm
+            volumes:
+              - name: test_no_size_volume
+                fs_type: ext4
+
+    - name: Fixup the volume size to be 100% of the pool for verification purposes
+      set_fact:
+        _storage_pools_list: "{{ _storage_pools_list | map('combine', {'volumes': fixed_volumes}) | list }}"
+      vars:
+        fixed_volumes: "{{ _storage_pools_list[0].volumes | map('combine', {'size': '100%'}) | list }}"
+
+    - name: Verify role results - 7
+      include_tasks: verify-role-results.yml
+
+    - name: Remove the LVM logical volume in 'test_no_size_pool' created above
+      include_role:
+        name: linux-system-roles.storage
+      vars:
+        storage_pools:
+          - name: test_no_size_pool
+            disks: "{{ unused_disks }}"
+            state: absent
+
+    - name: Verify role results - 8
+      include_tasks: verify-role-results.yml


### PR DESCRIPTION
Cause: The code was treating a volume with no size as having size `0`.

Consequence: Some of the size calculations would use this as the denominator when
calculating percentage used or available, leading to a divide by zero error.

Fix: If no size is specified, treat this as if the size were specified as 100%.  That
is, use all of the available space in the pool.

Result: The code works as expected when no size is specified.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Handle logical volumes without an explicit size by defaulting them to use all available space in the pool and document this behavior.

Bug Fixes:
- Prevent divide-by-zero errors when calculating usage for volumes that previously had an effective size of zero.

Documentation:
- Document that omitting a volume size is equivalent to specifying `size: 100%`.

Tests:
- Extend LVM percent size tests to cover volumes created without an explicit size and their removal.