### PR TITLE
ci: ansible-lint - remove .collection directory from converted collection [citest_skip]

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,7 +44,7 @@ jobs:
           TOXENV=collection lsr_ci_runtox
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
           # cleanup after collection conversion
-          rm -rf "$coll_dir/.ansible" .tox/ansible-plugin-scan
+          rm -rf "$coll_dir/.ansible" .tox/ansible-plugin-scan "$coll_dir/.collection"
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"


### PR DESCRIPTION
The new ansible-lint@v26 does not like it when there is a .collection directory
with a galaxy.yml in the converted collection, so remove it, since it is not
needed for ansible-lint.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Extend the ansible-lint workflow cleanup step to delete the converted collection's .collection directory in addition to existing artifacts.