### PR TITLE
ci: Add Fedora 43, remove Fedora 41 from Testing Farm CI

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -72,8 +72,8 @@ jobs:
           meta_main=meta/main.yml
           # All Fedora are supported, add latest Fedora versions to supported_platforms
           if yq '.galaxy_info.galaxy_tags[]' "$meta_main" | grep -qi fedora$; then
-            supported_platforms+=" Fedora-41"
             supported_platforms+=" Fedora-42"
+            supported_platforms+=" Fedora-43"
           fi
           # Specific Fedora versions supported
           if yq '.galaxy_info.galaxy_tags[]' "$meta_main" | grep -qiP 'fedora\d+$'; then
@@ -98,10 +98,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: Fedora-41
-            ansible_version: 2.17
           - platform: Fedora-42
             ansible_version: 2.19
+          - platform: Fedora-43
+            ansible_version: 2.20
           - platform: CentOS-7-latest
             ansible_version: 2.9
           - platform: CentOS-Stream-8


### PR DESCRIPTION
Add Fedora 43, remove Fedora 41 from Testing Farm CI

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update Testing Farm CI workflow to stop testing Fedora 41 and start testing Fedora 43.

CI:
- Adjust Testing Farm supported_platforms generation to include Fedora 43 instead of Fedora 41.
- Update CI test matrix to remove Fedora 41 and add Fedora 43 with a newer Ansible version.