### PR TITLE
fix: ensure libblockdev-loop package on EL7 for loop mounts

### DIFF
--- a/tests/tests_change_disk_mount.yml
+++ b/tests/tests_change_disk_mount.yml
@@ -8,6 +8,17 @@
     volume_size: '5g'
 
   tasks:
+    - name: Create blockdev and loop mount
+      shell: |
+        set -euxo pipefail
+        exec 1>&2
+        dd if=/dev/zero of=/tmp/loop.img bs=1024 count=64
+        mkfs.ext4 -v -F /tmp/loop.img
+        mkdir /mnt/loop_test
+        mount /tmp/loop.img /mnt/loop_test
+        cat /proc/mounts | grep loop
+      changed_when: false
+
     - name: Run the role
       include_role:
         name: linux-system-roles.storage
@@ -79,3 +90,11 @@
 
     - name: Verify role results - 4
       include_tasks: verify-role-results.yml
+
+    - name: Clean up loop mount
+      shell: |
+        set -euxo pipefail
+        exec 1>&2
+        umount /mnt/loop_test
+        rm -rf /tmp/loop.img /mnt/loop_test
+      changed_when: false

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -4,6 +4,7 @@ blivet_package_list:
   - python-blivet3
   - libblockdev-crypto
   - libblockdev-dm
+  - libblockdev-loop
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap


### PR DESCRIPTION
Cause: The blivet module on EL7 will try to use a function that is undefined when checking
for mounts if there is a loop mount (/dev/loopX) on the system.  The function is provided
by the libblockdev-loop package but that isn't always installed.

Consequence: The role will give an error like:
"The function 'bd_loop_get_backing_file' called, but not implemented"

Fix: Ensure that the libblockdev-loop package is installed if there are loop mounts
on the EL7 system.

Result: The role works on EL7 when there are loop mounts.

Added a test to create a loop mount.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Ensure EL7 systems with loop mounts have the required libblockdev-loop package installed to prevent blivet errors and add coverage for loop-mount scenarios in tests.

Bug Fixes:
- Install libblockdev-loop on EL7 systems with detected loop mounts to avoid blivet calling an undefined bd_loop_get_backing_file function.

Tests:
- Add an integration test that creates a loop-backed mount, runs the storage role, and then cleans up the loop device and mount.