### PR TITLE
test: ensure role gathers the facts it uses by having test clear_facts before include_role

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -55,15 +55,10 @@
     extra_pkgs:
       - kpartx
 
-- name: Get service facts
-  service_facts:
-  when: storage_skip_checks is not defined or
-        not "service_facts" in storage_skip_checks
-
-# rejectattr required because the fix to service_facts is on Ansible > 2.12 only
-# https://github.com/ansible/ansible/pull/75326
-- name: Set storage_cryptsetup_services
-  set_fact:
+- name: Manage storage devices and check for errors
+  vars:
+    # rejectattr required because the fix to service_facts is on Ansible > 2.12 only
+    # https://github.com/ansible/ansible/pull/75326
     storage_cryptsetup_services: "{{
       ansible_facts.services.values() |
       selectattr('name', 'defined') |
@@ -72,10 +67,15 @@
       rejectattr('status', 'match', '^failed$') |
       map(attribute='name') |
       select('match', '^systemd-cryptsetup@') |
-      list }}"
-
-- name: Manage storage devices and check for errors
+      list
+      if 'services' in ansible_facts else [] }}"
   block:
+    - name: Get service facts
+      service_facts:
+      when:
+        - not "services" in ansible_facts
+        - not "cryptsetup_services" in storage_skip_checks | d([])
+
     - name: Mask the systemd cryptsetup services
       systemd:
         name: "{{ item }}"

--- a/tests/tasks/run_role_with_clear_facts.yml
+++ b/tests/tasks/run_role_with_clear_facts.yml
@@ -1,0 +1,39 @@
+---
+# Task file: save facts, clear_facts, run linux-system-roles.storage, then restore facts.
+# Include this with include_tasks or import_tasks; ensure tests/library is in module search path.
+# Input:
+# - __sr_tasks_from: tasks_from to run - same as tasks_from in include_role
+# - __sr_public: export private vars from role - same as public in include_role
+# - __sr_failed_when: set to false to ignore role errors - same as failed_when in include_role
+# Output:
+# - ansible_facts: merged saved ansible_facts with ansible_facts modified by the role, if any
+- name: Clear facts
+  meta: clear_facts
+
+# note that you can use failed_when with import_role but not with include_role
+# so this simulates the __sr_failed_when false case
+# Q: Why do we need a separate task to run the role normally?  Why not just
+# run the role in the block and rethrow the error in the rescue block?
+# A: Because you cannot rethrow the error in exactly the same way as the role does.
+# It might be possible to exactly reconstruct ansible_failed_result but it's not worth the effort.
+- name: Run the role with __sr_failed_when false
+  when:
+    - __sr_failed_when is defined
+    - not __sr_failed_when
+  block:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.storage
+        tasks_from: "{{ __sr_tasks_from | default('main') }}"
+        public: "{{ __sr_public | default(false) }}"
+  rescue:
+    - name: Ignore the failure when __sr_failed_when is false
+      debug:
+        msg: Ignoring failure when __sr_failed_when is false
+
+- name: Run the role normally
+  include_role:
+    name: linux-system-roles.storage
+    tasks_from: "{{ __sr_tasks_from | default('main') }}"
+    public: "{{ __sr_public | default(false) }}"
+  when: __sr_failed_when | d(true)

--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -12,8 +12,7 @@
       else 'ext4' }}"
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -22,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -31,8 +29,7 @@
         max_return: 1
 
     - name: Create a disk device with the default file system type
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -44,8 +41,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the disk device file system type to {{ fs_type_after }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -58,8 +54,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -72,8 +67,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_change_disk_mount.yml
+++ b/tests/tests_change_disk_mount.yml
@@ -20,8 +20,7 @@
       changed_when: false
 
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -30,7 +29,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -39,8 +37,7 @@
         max_return: 1
 
     - name: Create a disk device mounted at "{{ mount_location_before }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -52,8 +49,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the disk device mount location to {{ mount_location_after }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -65,8 +61,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -78,8 +73,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -14,8 +14,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -24,7 +23,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -33,8 +31,7 @@
         max_return: 1
 
     - name: Create a LVM logical volume with default fs_type
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -48,8 +45,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the file system signature on the logical volume created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -64,8 +60,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Re-run the role on the same volume without specifying fs_type
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -86,8 +81,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -102,8 +96,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the FS
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -116,10 +109,8 @@
     - name: Verify role results - 5
       include_tasks: verify-role-results.yml
 
-
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -15,8 +15,7 @@
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -25,7 +24,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -34,8 +32,7 @@
         max_return: 1
 
     - name: Create an LVM partition with the default file system type
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: bar
@@ -49,8 +46,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the LVM partition file system type to {{ fs_type_after }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: bar
@@ -65,8 +61,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: bar
@@ -81,8 +76,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: bar

--- a/tests/tests_change_mount.yml
+++ b/tests/tests_change_mount.yml
@@ -11,8 +11,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -21,7 +20,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -30,8 +28,7 @@
         max_return: 1
 
     - name: Create a LVM logical volume mounted at {{ mount_location_before }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -45,8 +42,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the mount location to {{ mount_location_after }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -60,8 +56,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -75,8 +70,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -8,14 +8,12 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - service_facts
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
@@ -28,8 +26,7 @@
     - name: >-
         Create a disk device; specify disks as non-list mounted on
         {{ mount_location }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -45,8 +42,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation minus fs_type to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -68,8 +64,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -7,15 +7,12 @@
     mount_location: '/opt/test1'
     volume_group_size: '10g'
     lv_size: '10g'
-    unused_disk_subfact: '{{ ansible_facts["devices"][unused_disks[0]] }}'
-    disk_size: '{{ unused_disk_subfact.sectors | int * 512 }}'
   tags:
     - tests::lvm
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -24,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -33,8 +29,7 @@
         max_return: 1
 
     - name: Create one lv which size is equal to vg size
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -48,8 +43,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_create_lvm_cache_then_remove.yml
+++ b/tests/tests_create_lvm_cache_then_remove.yml
@@ -13,8 +13,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -23,7 +22,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Gather package facts
       package_facts:
@@ -58,8 +56,7 @@
         match_sector_size: true
 
     - name: Create a cached LVM logical volume under volume group 'foo'
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -75,8 +72,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove (detach) cache from the 'test' LV created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -96,8 +92,7 @@
              is_rhel10)
       block:
         - name: Attach the cache to the 'test' LV created above
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -113,8 +108,7 @@
           include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -14,8 +14,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -24,7 +23,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -33,8 +31,7 @@
         max_return: 1
 
     - name: Create two LVM logical volumes under volume group 'foo'
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -51,8 +48,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove one of the LVM logical volumes in 'foo' created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -71,8 +67,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -90,8 +85,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove both of the LVM logical volumes in 'foo' created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -14,14 +14,12 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - service_facts
 
     - name: Gather package facts
       package_facts:
@@ -55,11 +53,14 @@
       changed_when: false
       register: __storage_dmvdo_loadable
 
+    - name: Set flag for Fedora
+      set_fact:
+        is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
+
     - name: Run tests if VDO is available
       when:
         - blivet_pkg_version is version("3.2.2-10", ">=")
-        - ansible_facts["distribution"] != "Fedora" or
-          libblockdev_pkg_version is version("3.1.1-2", ">=")
+        - not is_fedora or libblockdev_pkg_version is version("3.1.1-2", ">=")
         - __storage_kvdo_loadable is success or __storage_dmvdo_loadable is success
       block:
         - name: Get unused disks
@@ -69,8 +70,7 @@
             max_return: 1
 
         - name: Create LVM VDO volume under volume group 'pool1'
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: pool1
@@ -87,8 +87,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Repeat the previous invocation to verify idempotence
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: pool1
@@ -105,8 +104,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Remove LVM VDO volume in 'pool1' created above
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: pool1
@@ -126,8 +124,7 @@
         - name: >-
             Create LVM VDO volume under volume group 'pool1' (this time
             default size)
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: pool1
@@ -143,8 +140,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Remove LVM VDO volume in 'pool1' created above - 2
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: pool1

--- a/tests/tests_create_multiple_partitions_dos.yml
+++ b/tests/tests_create_multiple_partitions_dos.yml
@@ -11,8 +11,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -21,7 +20,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -47,8 +45,7 @@
                   mount_point: /opt/test
 
     - name: Create three partitions
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -73,8 +70,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -99,8 +95,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove all partitions
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"

--- a/tests/tests_create_multiple_partitions_gpt.yml
+++ b/tests/tests_create_multiple_partitions_gpt.yml
@@ -11,8 +11,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -21,7 +20,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -29,8 +27,7 @@
         max_return: 1
 
     - name: Create two partitions
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -50,8 +47,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -71,8 +67,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Add third partition
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -96,8 +91,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Resize third partition
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -121,8 +115,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -146,8 +139,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the first partition created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -167,8 +159,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove all partitions
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -180,8 +171,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create two encrypted partitions
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -205,8 +195,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove all partitions
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -8,8 +8,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -18,7 +17,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -26,8 +24,7 @@
         max_return: 1
 
     - name: Create a partition device mounted on {{ mount_location }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -43,8 +40,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation minus fs_type to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -66,8 +62,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the partition created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -84,8 +79,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -16,8 +16,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -26,7 +25,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Gather package facts
       package_facts:
@@ -59,8 +57,7 @@
         disks_needed: 2
 
     - name: Create a RAID0 device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -83,8 +80,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -107,8 +103,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the device created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -131,8 +126,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID1 lvm raid device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -150,8 +144,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -169,8 +162,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the device created above - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -188,8 +180,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID0 lvm raid device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -207,8 +198,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -226,8 +216,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the device created above - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -245,8 +234,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID1 lvm raid device on encrypted VG
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -266,8 +254,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the device created above - 4
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -285,8 +272,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create encrypted RAID1 LVM device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -303,8 +289,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the device created above - 5
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -328,8 +313,7 @@
              is_rhel10)
       block:
         - name: Create a RAID0 lvm raid device with custom stripe size
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: vg1
@@ -348,8 +332,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Remove the device created above - 6
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: vg1

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -9,8 +9,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -19,7 +18,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -28,8 +26,7 @@
         disks_needed: 2
 
     - name: Create a RAID0 device mounted on {{ mount_location }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -42,8 +39,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -56,8 +52,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_create_thinp_then_remove.yml
+++ b/tests/tests_create_thinp_then_remove.yml
@@ -10,14 +10,9 @@
     mount_location3: '/opt/test3'
     volume1_size: '3g'
     volume2_size: '4g'
-    fs_after: "{{ (ansible_facts['distribution'] == 'RedHat' and
-                   ansible_facts['distribution_major_version'] == '6') |
-      ternary('ext4', 'xfs') }}"
-
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -26,8 +21,7 @@
         match_sector_size: true
 
     - name: Create a thinpool device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -46,8 +40,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -65,8 +58,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change thinlv fs type
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -76,14 +68,16 @@
               - name: lv1
                 thin_pool_name: tpool1
                 thin: true
-                fs_type: "{{ fs_after }}"
+                fs_type: "{{
+                  (ansible_facts['distribution'] == 'RedHat' and
+                   ansible_facts['distribution_major_version'] == '6') |
+                  ternary('ext4', 'xfs') }}"
 
     - name: Verify role results - 3
       include_tasks: verify-role-results.yml
 
     - name: Create new LV under existing thinpool
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -100,8 +94,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove existing LV under existing thinpool
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -118,8 +111,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Cleanup
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -138,8 +130,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create a thinpool device using percentages
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -158,8 +149,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Cleanup - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
-  gather_facts: false
-  roles:
-    - linux-system-roles.storage
+  tasks:
+    - name: Run the role
+      include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_deps.yml
+++ b/tests/tests_deps.yml
@@ -5,9 +5,9 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
-        public: true
+      include_tasks: tasks/run_role_with_clear_facts.yml
+      vars:
+        __sr_public: true
 
     - name: Test lvm and xfs package deps
       include_tasks: run_blivet.yml

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -9,8 +9,7 @@
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -19,7 +18,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -64,8 +62,7 @@
               disks: "{{ unused_disks }}"
 
     - name: Create a file system on disk
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -95,8 +92,7 @@
               disks: "{{ unused_disks }}"
 
     - name: Unmount file system
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -120,8 +116,7 @@
               disks: "{{ unused_disks }}"
 
     - name: Remount file system
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -180,8 +175,7 @@
     - name: >-
         Create a partition pool on the disk already containing a file system
         w/o safe_mode
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -197,8 +191,7 @@
           safe_mode
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:

--- a/tests/tests_existing_lvm_pool.yml
+++ b/tests/tests_existing_lvm_pool.yml
@@ -12,8 +12,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -22,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -31,8 +29,7 @@
         max_return: 1
 
     - name: Create one LVM logical volume under one volume group
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ pool_name }}"
@@ -45,8 +42,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create another volume in the existing pool, identified only by name.
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ pool_name }}"
@@ -60,8 +56,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up.
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ pool_name }}"

--- a/tests/tests_fatals_cache_volume.yml
+++ b/tests/tests_fatals_cache_volume.yml
@@ -12,8 +12,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -22,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml

--- a/tests/tests_fatals_raid_pool.yml
+++ b/tests/tests_fatals_raid_pool.yml
@@ -16,8 +16,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -26,7 +25,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml

--- a/tests/tests_fatals_raid_volume.yml
+++ b/tests/tests_fatals_raid_volume.yml
@@ -9,8 +9,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -19,7 +18,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml

--- a/tests/tests_filesystem_one_disk.yml
+++ b/tests/tests_filesystem_one_disk.yml
@@ -7,8 +7,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -17,7 +16,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -25,8 +23,7 @@
         max_return: 1
 
     - name: Initialize a disk device with the default fs type
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -38,8 +35,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -51,8 +47,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test role variable override
   hosts: all
-  gather_facts: true
   tasks:
     - name: Create var file in caller that can override the one in called role
       delegate_to: localhost

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -72,8 +72,7 @@
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -100,8 +99,7 @@
 
     # encrypted disk volume
     - name: Create an encrypted disk volume w/ default fs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo
@@ -138,8 +136,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_volumes:
@@ -177,8 +174,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_volumes:
@@ -216,8 +212,7 @@
                   encryption: true
 
     - name: Create an encrypted partition volume w/ default fs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -263,8 +258,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -326,8 +320,7 @@
           changed_when: false
 
         - name: Add encryption to the volume - 2
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_safe_mode: false
             storage_pools:
@@ -377,8 +370,7 @@
                   encryption: true
 
     - name: Create an encrypted lvm volume w/ default fs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -399,8 +391,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Verify preservation of encryption settings on existing LVM volume
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -449,8 +440,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -494,8 +484,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -513,8 +502,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo

--- a/tests/tests_luks2.yml
+++ b/tests/tests_luks2.yml
@@ -72,8 +72,7 @@
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -101,8 +100,7 @@
 
     # encrypted disk volume
     - name: Create an encrypted disk volume w/ default fs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo
@@ -141,8 +139,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_volumes:
@@ -182,8 +179,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_volumes:
@@ -223,8 +219,7 @@
                   encryption_luks_version: luks2
 
     - name: Create an encrypted partition volume w/ default fs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -272,8 +267,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -337,8 +331,7 @@
           changed_when: false
 
         - name: Add encryption to the volume - 2
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_safe_mode: false
             storage_pools:
@@ -387,8 +380,7 @@
                   encryption_luks_version: luks2
 
     - name: Create an encrypted lvm volume w/ default fs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -409,8 +401,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Verify preservation of encryption settings on existing LVM volume
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -460,8 +451,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -507,8 +497,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the volume - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -527,8 +516,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -56,14 +56,12 @@
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
         storage_skip_checks:
           - blivet_available
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -99,7 +97,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Test key file handling
       block:
@@ -118,8 +115,7 @@
           changed_when: false
 
         - name: Create an encrypted lvm pool using a key file
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -167,8 +163,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Remove the encryption layer
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -214,8 +209,7 @@
       import_tasks: verify-data-preservation.yml
 
     - name: Add encryption to the pool
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -239,8 +233,7 @@
       import_tasks: create-test-file.yml
 
     - name: Change the mountpoint, leaving encryption in place
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -264,8 +257,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo

--- a/tests/tests_lvm_auto_size_cap.yml
+++ b/tests/tests_lvm_auto_size_cap.yml
@@ -6,8 +6,7 @@
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -16,7 +15,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -66,8 +64,7 @@
 
     - name: >-
         Create a pool containing one volume the same size as the backing disk
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -80,8 +77,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -95,8 +91,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -11,13 +11,11 @@
     invalid_disks:
       - '/non/existent/disk'
     invalid_size: 'xyz GiB'
-    unused_disk_subfact: '{{ ansible_facts["devices"][unused_disks[0]] }}'
   tags:
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -26,7 +24,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -126,8 +123,7 @@
                   mount_point: "{{ mount_location2 }}"
 
     - name: Create a pool
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: testpool1
@@ -185,8 +181,7 @@
                 - "{{ unused_disks[0] }}"
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:
@@ -213,8 +208,7 @@
                   mount_point: "{{ mount_location1 }}"
 
     - name: Clean up - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_safe_mode: false
         storage_pools:

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -11,8 +11,7 @@
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -21,7 +20,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -34,8 +32,7 @@
     - name: >-
         Create a logical volume spanning two physical volumes that changes its
         mount location
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: phi
@@ -52,8 +49,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: phi
@@ -70,8 +66,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: phi

--- a/tests/tests_lvm_one_disk_multiple_volumes.yml
+++ b/tests/tests_lvm_one_disk_multiple_volumes.yml
@@ -10,8 +10,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -20,7 +19,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -29,8 +27,7 @@
         max_return: 1
 
     - name: Create three LVM logical volumes under one volume group
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -50,8 +47,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -71,8 +67,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove two of the LVs
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -94,8 +89,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Re-run the previous role invocation to ensure idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -117,8 +111,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_lvm_one_disk_one_volume.yml
+++ b/tests/tests_lvm_one_disk_one_volume.yml
@@ -11,8 +11,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -21,7 +20,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -30,8 +28,7 @@
         max_return: 1
 
     - name: Create one LVM logical volume under one volume group
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -45,8 +42,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -60,8 +56,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -15,8 +15,7 @@
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -44,8 +43,7 @@
     - name: >-
         Create two LVM logical volumes under volume group 'foo' using percentage
         sizes
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -63,8 +61,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -81,8 +78,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Shrink test2 volume via percentage-based size spec
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -104,8 +100,7 @@
       changed_when: false
 
     - name: Remove the test1 volume without changing its size
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -134,8 +129,7 @@
           storage_test_test1_size_2.stdout
 
     - name: Grow test2 using a percentage-based size spec
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -150,8 +144,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove both of the LVM logical volumes in 'foo' created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -162,8 +155,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create an LVM logical volume with no size specified
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: test_no_size_pool
@@ -183,8 +175,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the LVM logical volume in 'test_no_size_pool' created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: test_no_size_pool

--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -12,8 +12,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -22,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Gather package facts
       package_facts:
@@ -38,6 +36,14 @@
           ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
           '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
 
+    - name: Set distribution version flags
+      set_fact:
+        is_rhel10: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '10' }}"
+        is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '9' }}"
+        is_rhel8: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8' }}"
+        is_rhel7: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7' }}"
+        is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
+
     # end early when running with old blivet where removing PVs from a VG fails
     - name: Run test only if blivet supports this functionality
       when: (blivet_pkg_version is defined and
@@ -46,16 +52,6 @@
               (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
               (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">=")) or
               is_rhel10))
-      vars:
-        is_rhel10: "{{ ansible_facts['os_family'] == 'RedHat' and
-          ansible_facts['distribution_major_version'] == '10' }}"
-        is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and
-          ansible_facts['distribution_major_version'] == '9' }}"
-        is_rhel8: "{{ ansible_facts['os_family'] == 'RedHat' and
-          ansible_facts['distribution_major_version'] == '8' }}"
-        is_rhel7: "{{ ansible_facts['os_family'] == 'RedHat' and
-          ansible_facts['distribution_major_version'] == '7' }}"
-        is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
       block:
         - name: Get unused disks
           include_tasks: get_unused_disk.yml
@@ -65,8 +61,7 @@
             match_sector_size: true
 
         - name: Create volume group 'foo' with 3 PVs
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -81,8 +76,7 @@
           register: storage_test_members_vg_uuid
 
         - name: Verify that nothing changes when disks don't change
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -102,8 +96,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Remove 2 PVs from the 'foo' volume group
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -133,8 +126,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Add the second disk back to the 'foo' volume group
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -155,8 +147,7 @@
 
         - name: >-
             Remove the first PV and add the third disk to the 'foo' volume group
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -176,8 +167,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Create volume group 'foo' with 3 encrypted PVs
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_safe_mode: false
             storage_pools:
@@ -192,8 +182,7 @@
           register: storage_test_members_vg_uuid
 
         - name: Remove 2 PVs from the 'foo' volume group - 2
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -215,8 +204,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Add the disks back to the 'foo' volume group
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -238,8 +226,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Create a new volume group with a logical volume
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -258,8 +245,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Add a second PV to the VG
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -279,8 +265,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Remove the first PV from the VG
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -310,8 +295,7 @@
               storage_test_members_vg_uuid_after.stdout
 
         - name: Clean up
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo

--- a/tests/tests_lvm_pool_pv_grow.yml
+++ b/tests/tests_lvm_pool_pv_grow.yml
@@ -11,15 +11,14 @@
   tasks:
     - name: Test
       block:
+
         - name: Run the role
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
 
         - name: Mark tasks to be skipped
           set_fact:
             storage_skip_checks:
               - blivet_available
-              - service_facts
               - "{{ (lookup('env',
                             'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                     ternary('packages_installed', '') }}"
@@ -45,8 +44,7 @@
           changed_when: vgcreate_output.rc != 0
 
         - name: Create LVM
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -61,8 +59,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Rerun the task to verify idempotence
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -77,9 +74,9 @@
           include_tasks: verify-role-results.yml
 
       always:
+
         - name: Remove 'foo' pool created above
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -88,5 +85,5 @@
                 volumes:
                   - name: test1
 
-    - name: Verify role results - 3
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 3
+          include_tasks: verify-role-results.yml

--- a/tests/tests_lvm_pool_shared.yml
+++ b/tests/tests_lvm_pool_shared.yml
@@ -42,8 +42,7 @@
           when: inventory_hostname == "localhost"
 
         - name: Run the role to install blivet
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
 
         - name: Gather package facts
           package_facts:
@@ -116,8 +115,7 @@
         - name: >-
             Create a disk device; specify disks as non-list mounted on
             {{ mount_location }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: vg1
@@ -136,8 +134,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Repeat the previous step to verify idempotence
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: vg1
@@ -158,8 +155,7 @@
         - name: >-
             Remove the device created above
             {{ mount_location }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: vg1

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -13,8 +13,7 @@
     - tests::lvm
   tasks:
     - name: Include the role to ensure packages are installed
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -23,7 +22,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks for test
       include_tasks: get_unused_disk.yml
@@ -32,8 +30,7 @@
         max_return: 1
 
     - name: Test creating ext4 filesystem with valid parameter "-Fb 4096"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -50,8 +47,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the volume group created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -87,8 +83,7 @@
                   mount_point: "{{ mount_location }}"
 
     - name: Remove the volume group created above - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -99,8 +94,7 @@
     - name: >-
         Create one LVM logical volume under one volume group, size
         {{ volume1_size }}
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -134,8 +128,7 @@
                   mount_point: "{{ mount_location }}"
 
     - name: Remove the volume group created above - 3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -144,8 +137,7 @@
             state: absent
 
     - name: Create one partition on one disk
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -161,8 +153,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Test setting up disk volume will remove the partition create above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo
@@ -179,8 +170,7 @@
         __storage_verify_mount_options: true
 
     - name: Remove the disk volume created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: foo
@@ -220,8 +210,7 @@
               mount_point: "{{ mount_location }}"
 
     - name: Remove the disk volume created above - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_missing_volume_type_in_pool.yml
+++ b/tests/tests_missing_volume_type_in_pool.yml
@@ -8,8 +8,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -18,7 +17,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -26,8 +24,7 @@
         max_return: 1
 
     - name: Create a partition device mounted on "{{ mount_location }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -47,8 +44,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the partition created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"
@@ -69,8 +65,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: "{{ unused_disks[0] }}"

--- a/tests/tests_null_raid_pool.yml
+++ b/tests/tests_null_raid_pool.yml
@@ -12,8 +12,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -22,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -36,8 +34,7 @@
       changed_when: false
 
     - name: Check that raid_level null does not create raid
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -57,8 +54,7 @@
 
     # Cleanup before assert so it is always executed
     - name: Cleanup
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -16,8 +16,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -26,7 +25,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -35,8 +33,7 @@
         disks_needed: 3
 
     - name: Create a RAID1 device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -62,8 +59,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation minus the pool raid options
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -94,8 +90,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the pool created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -121,8 +116,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create a RAID0 device
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1
@@ -138,8 +132,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the pool created above - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: vg1

--- a/tests/tests_raid_volume_cleanup.yml
+++ b/tests/tests_raid_volume_cleanup.yml
@@ -12,15 +12,13 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
         storage_skip_checks:
           - blivet_available
           - packages_installed
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -29,8 +27,7 @@
         disks_needed: 3
 
     - name: Create two LVM logical volumes under volume group 'foo'
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -71,8 +68,7 @@
         storage_safe_mode: false
 
     - name: Create a RAID0 device mounted on "{{ mount_location1 }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -88,8 +84,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Cleanup - remove the disk device created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -9,8 +9,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -19,7 +18,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -28,8 +26,7 @@
         disks_needed: 3
 
     - name: Create a RAID0 device mounted on "{{ mount_location }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -46,8 +43,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Re-run the same invocation without the RAID params
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -69,8 +65,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -87,8 +82,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Create again a RAID0 device mounted on "{{ mount_location }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test0
@@ -105,8 +99,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove the disk device created above - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test0

--- a/tests/tests_remove_mount.yml
+++ b/tests/tests_remove_mount.yml
@@ -11,8 +11,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -21,7 +20,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -30,8 +28,7 @@
         max_return: 1
 
     - name: Create a LVM logical volume mounted at "{{ mount_location_before }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -45,8 +42,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the mount location to "{{ mount_location_after }}"
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -60,8 +56,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -75,8 +70,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -14,8 +14,7 @@
   # caused crash
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -24,7 +23,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -32,8 +30,7 @@
         max_return: 1
 
     - name: Removing nonexistent pool (with listed volumes)
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo
@@ -47,8 +44,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Removing nonexistent pool
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools:
           - name: foo

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -10,7 +10,7 @@
     volume_size_after: '9g'
     invalid_size1: xyz GiB
     invalid_size2: none
-    unused_disk_subfact: '{{ ansible_facts["devices"][unused_disks[0]] }}'
+    unused_disk_subfact: "{{ ansible_facts['devices'][unused_disks[0]] }}"
     too_large_size: '{{ unused_disk_subfact.sectors | int * 1.2 * 512 }}'
     acc_large_size: '{{ unused_disk_subfact.sectors | int * 1.015 * 512 }}'
     acc_small_size: '{{ unused_disk_subfact.sectors | int * 0.985 * 512 }}'
@@ -19,8 +19,7 @@
     - tests::lvm
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -29,7 +28,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -41,11 +39,11 @@
 
     - name: Test ext4
       block:
+
         - name: >-
             Create one LVM logical volume under one volume group with size
             {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -62,8 +60,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Change volume_size to {{ volume_size_after }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -79,8 +76,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Change volume size to {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -113,11 +109,11 @@
 
         - name: Test for correct handling of volume size equal disk's size
           block:
+
             - name: >-
                 Try to create LVM with volume size equal disk's size, resize to
                 {{ disk_size }}
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -133,11 +129,11 @@
 
         - name: Test for correct handling of acceptable size difference (slightly bigger than max)
           block:
+
             - name: >-
                 Try to resize LVM volume size to disk size + 1.5 % (less than 2 % than
                 maximum size should be tolerated)
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -184,9 +180,9 @@
                       mount_point: "{{ mount_location }}"
 
       always:
+
         - name: Clean up
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -204,11 +200,11 @@
 
     - name: Test ext3
       block:
+
         - name: >-
             Create a LVM logical volume with for ext3 FS size
             {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -224,8 +220,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Change volume size to {{ volume_size_after }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -241,8 +236,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Change volume size to before size {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -258,9 +252,9 @@
           include_tasks: verify-role-results.yml
 
       always:
+
         - name: Clean up - 2
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -278,11 +272,11 @@
 
     - name: Test ext2
       block:
+
         - name: >-
             Create a LVM logical volume with for ext2 FS size
             {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -298,8 +292,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Change volume size to after size {{ volume_size_after }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -315,8 +308,7 @@
           include_tasks: verify-role-results.yml
 
         - name: Change again volume size to before size {{ volume_size_before }}
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -333,8 +325,7 @@
 
       always:
         - name: Clean up - 3
-          include_role:
-            name: linux-system-roles.storage
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
               - name: foo
@@ -381,11 +372,11 @@
                 (is_rhel9 and blivet_pkg_version is version("3.6.0-8", ">=")) or
                 is_rhel10)
           block:
+
             - name: >-
                 Create one LVM logical volume under one volume group with size
                 {{ volume_size_before }}
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -401,8 +392,7 @@
               include_tasks: verify-role-results.yml
 
             - name: Change volume_size to after size {{ volume_size_after }}
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -435,9 +425,9 @@
                           mount_point: "{{ mount_location }}"
 
           always:
+
             - name: Clean up - 4
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -460,11 +450,11 @@
                 (is_rhel8 and blivet_pkg_version is version("3.4.0-1", ">=")) or
                 is_rhel9 or is_rhel10)
           block:
+
             - name: >-
                 Create a LVM logical volume with for XFS size
                 {{ volume_size_before }}
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -480,8 +470,7 @@
               include_tasks: verify-role-results.yml
 
             - name: Change again volume size to after size {{ volume_size_after }}
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -497,8 +486,7 @@
               include_tasks: verify-role-results.yml
 
             - name: Repeat for idempotency test
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -531,11 +519,11 @@
 
             - name: Test for correct handling of acceptable size difference (slightly smaller than min)
               block:
+
                 - name: >-
                     Try to resize LVM volume size to disk size - 1.5 % (less than 2 % than
                     minimum size should be tolerated)
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -551,8 +539,7 @@
 
           always:
             - name: Clean up - 5
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo

--- a/tests/tests_safe_mode_check.yml
+++ b/tests/tests_safe_mode_check.yml
@@ -14,8 +14,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -24,7 +23,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -12,8 +12,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -22,7 +21,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Gather package facts
       package_facts:
@@ -49,7 +47,6 @@
                     ansible_facts.distribution_major_version == '10' }}"
         is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
-
     - name: Completely skip this on RHEL/CentOS 7 and 8 where Stratis isn't supported by blivet
       when: not is_rhel78
       block:
@@ -68,9 +65,9 @@
 
         - name: One pool/volume test
           block:
+
             - name: Create one Stratis pool with one volume
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -85,8 +82,7 @@
               include_tasks: verify-role-results.yml
 
             - name: Repeat the previous invocation to verify idempotence
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -101,8 +97,7 @@
               include_tasks: verify-role-results.yml
 
             - name: Add second filesystem to the pool
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -120,9 +115,9 @@
               include_tasks: verify-role-results.yml
 
           always:
+
             - name: Clean up
-              include_role:
-                name: linux-system-roles.storage
+              include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 storage_pools:
                   - name: foo
@@ -149,9 +144,9 @@
           block:
             - name: Test encrypted pool
               block:
+
                 - name: Create encrypted Stratis pool
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -168,8 +163,7 @@
                   include_tasks: verify-role-results.yml
 
                 - name: Repeat the previous invocation to verify idempotence - 2
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -186,9 +180,9 @@
                   include_tasks: verify-role-results.yml
 
               always:
+
                 - name: Clean up - 2
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -206,9 +200,9 @@
 
             - name: Test one disk pool
               block:
+
                 - name: Create one Stratis pool on one disk
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -219,8 +213,7 @@
                   include_tasks: verify-role-results.yml
 
                 - name: Add the second disk to the pool
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -231,9 +224,9 @@
                   include_tasks: verify-role-results.yml
 
               always:
+
                 - name: Clean up - 3
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -260,8 +253,7 @@
             - name: Clevis/Tang test
               block:
                 - name: Create encrypted Stratis pool with Clevis/Tang
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo
@@ -277,8 +269,7 @@
 
               always:
                 - name: Clean up - 4
-                  include_role:
-                    name: linux-system-roles.storage
+                  include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     storage_pools:
                       - name: foo

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -5,11 +5,11 @@
     storage_safe_mode: false
     mount_location: /opt/test
     volume_size: '5g'
-
+    __swap_disk: "{{ unused_disks[0] }}"
+    __non_swap_disk: "{{ unused_disks[1] }}"
   tasks:
     - name: Include role to ensure packages are installed
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -18,26 +18,20 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     # rhel7 has a limitation of 128g swap size
     - name: Get unused disks for swap
       include_tasks: get_unused_disk.yml
       vars:
         min_size: "{{ volume_size }}"
-        max_return: 1
-        disks_needed: 1
+        max_return: 2
+        disks_needed: 2
         max_size: "{{ '127g' if (ansible_facts['os_family'] == 'RedHat'
           and ansible_facts['distribution_major_version'] is version('8', '<'))
           else '0' }}"
 
-    - name: Save disk used for swap
-      set_fact:
-        __swap_disk: "{{ unused_disks[0] }}"
-
     - name: Create a disk device with swap
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -48,20 +42,8 @@
     - name: Verify results
       include_tasks: verify-role-results.yml
 
-    - name: Get disk to use for non-swap device
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
-        disks_needed: 1
-
-    - name: Save non-swap disk
-      set_fact:
-        __non_swap_disk: "{{ unused_disks[0] }}"
-
     - name: Format second disk as ext3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test2
@@ -74,8 +56,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change the disk device file system type from swap to ext3
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -88,8 +69,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -102,8 +82,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Change it back to swap
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -115,8 +94,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Repeat the previous invocation to verify idempotence - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -128,8 +106,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -9,8 +9,7 @@
 
   tasks:
     - name: Run the role
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
 
     - name: Mark tasks to be skipped
       set_fact:
@@ -19,7 +18,6 @@
           - "{{ (lookup('env',
                         'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
                 ternary('packages_installed', '') }}"
-          - service_facts
 
     - name: Get unused disks
       include_tasks: get_unused_disk.yml
@@ -28,8 +26,7 @@
         max_return: 1
 
     - name: Set label
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -43,8 +40,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Relabel
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -58,8 +54,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Run relabel again to verify idempotence
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -78,8 +73,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Relabel without explicitly setting the label
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -97,8 +91,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Remove label
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -112,8 +105,7 @@
       include_tasks: verify-role-results.yml
 
     - name: Format the device to LVMPV which doesn't support labels
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -122,8 +114,7 @@
             disks: "{{ unused_disks }}"
 
     - name: Rerun to check we don't try to relabel preexisitng LVMPV (regression test for RHEL-29874)
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1
@@ -132,8 +123,7 @@
             disks: "{{ unused_disks }}"
 
     - name: Clean up
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_volumes:
           - name: test1

--- a/tests/verify-role-failed.yml
+++ b/tests/verify-role-failed.yml
@@ -8,8 +8,7 @@
         storage_volumes_global: "{{ storage_volumes | d([]) }}"
 
     - name: Verify role raises correct error - 2
-      include_role:
-        name: linux-system-roles.storage
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         storage_pools: "{{
           __storage_failed_params.get('storage_pools',

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,7 +11,7 @@ __storage_required_facts:
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of
 # the 'gather_subset' parameter of the 'setup' module
-__storage_required_facts_subsets: "{{ ['!all', '!min'] +
+__storage_required_facts_subsets: "{{ ['!all', '!min', 'devices'] +
   __storage_required_facts }}"
 
 # Set flag for blivet to know if there is a kmod-kvdo package


### PR DESCRIPTION
The role gathers the facts it uses.  For example, if the user uses
`ANSIBLE_GATHERING=explicit`, the role uses the `setup` module with the
facts and subsets it requires.

This change allows us to test this.  Before every role invocation, the test
will use `meta: clear_facts` so that the role starts with no facts.  

Create a task file tests/tasks/run_role_with_clear_facts.yml to do the tasks
to clear the facts and run the role.  Note that this means we don't need to
use `gather_facts` for the tests.

Some vars defined using `ansible_facts` have been changed to be defined with
`set_fact` instead.  This is because of the fact that `vars` are lazily
evaluated - the var might be referenced when the facts have been cleared, and
will issue an error like `ansible_facts["distribution"] is undefined`.  This is
typically done for blocks that have a `when` condition that uses `ansible_facts`
and the block has a role invocation using run_role_with_clear_facts.yml
These have been rewritten to define the `when` condition using `set_fact`.  This
is because the `when` condition is evaluated every time a task is invoked in the
block, and if the facts are cleared, this will raise an undefined variable error.

## Summary by Sourcery

Ensure storage role tests run with cleared Ansible facts so the role gathers required facts itself before execution.

Enhancements:
- Make cryptsetup service masking conditional on service facts being present, gathering them only when needed.
- Extend the role’s required fact subsets to explicitly include device facts.

Tests:
- Run the storage role in all tests via a helper task file that clears facts before including the role, replacing direct include_role usage.
- Adjust test playbooks to no longer rely on service_facts-based skip checks and to set OS/version flags and helper vars using set_fact where needed.
- Update default test play and dependency test to invoke the role through the new helper, preserving public variable behavior.