### PR TITLE
feat: add role fingerprint to system journal

### DIFF
--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.11.txt
+++ b/.sanity-ansible-ignore-2.11.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.16.txt
+++ b/.sanity-ansible-ignore-2.16.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.17.txt
+++ b/.sanity-ansible-ignore-2.17.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.18.txt
+++ b/.sanity-ansible-ignore-2.18.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.19.txt
+++ b/.sanity-ansible-ignore-2.19.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.20.txt
+++ b/.sanity-ansible-ignore-2.20.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.21.txt
+++ b/.sanity-ansible-ignore-2.21.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.22.txt
+++ b/.sanity-ansible-ignore-2.22.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -5,3 +5,4 @@ plugins/modules/find_unused_disk.py validate-modules:missing-gplv3-license
 plugins/modules/lvm_gensym.py validate-modules:missing-gplv3-license
 plugins/modules/resolve_blockdev.py validate-modules:missing-gplv3-license
 tests/storage/scripts/generate_tests.py shebang!skip
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/library/sr_fingerprint.py
+++ b/library/sr_fingerprint.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: sr_fingerprint
+short_description: Write a message string to syslog using Ansible C(module.log) function.
+description:
+    - Writes the given string to the system log using Ansible C(module.log) function.
+    - Intended for role-internal or diagnostic use.
+author: Rich Megginson (@richm)
+options:
+    sr_message:
+        description: Text to record in syslog.
+        type: str
+        required: true
+"""
+
+EXAMPLES = """
+- name: Record a fingerprint message in syslog
+  sr_fingerprint:
+    sr_message: "system_role:ROLENAME"
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+import datetime
+
+
+def _local_iso8601_no_microseconds():
+    """System local wall clock with local tz offset, ISO 8601, seconds only."""
+    try:
+        utc = datetime.timezone.utc
+    except AttributeError:
+        import time
+
+        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+    # Prefer the local clock interpreted in the system timezone (not UTC displayed).
+    now = datetime.datetime.now()
+    astimezone = getattr(now, "astimezone", None)
+    if astimezone is not None:
+        try:
+            return astimezone().replace(microsecond=0).isoformat()
+        except (OSError, TypeError, ValueError):
+            pass
+    return datetime.datetime.now(utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def run_module():
+    module_args = dict(
+        sr_message=dict(type="str", required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    log_message = "%s %s" % (
+        module.params["sr_message"],
+        _local_iso8601_no_microseconds(),
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            message="Check mode: message not logged - [%s]" % log_message,
+        )
+
+    module.log(log_message)
+
+    # we don't actually change anything, so we're not changed - writing a log message
+    # is not considered a change
+    # also, we don't want to report changed every time the role runs
+    module.exit_json(changed=False)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,9 @@
 
 - name: Include the appropriate provider tasks
   include_tasks: "main-{{ storage_provider }}.yml"
+
+- name: Record role success fingerprint
+  sr_fingerprint:
+    sr_message: >-
+      success system_role:storage ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,6 +5,12 @@
   when: __storage_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
+- name: Record role begin fingerprint
+  sr_fingerprint:
+    sr_message: >-
+      begin system_role:storage ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,5 +2,21 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   tasks:
+    - name: Set the start time for the journal search
+      set_fact:
+        __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
+
+    # look for the exact module invocation, not some other message that might contain the string
+    - name: Check system journal contains role fingerprints
+      shell: >-
+        set -eo pipefail;
+        journalctl --since "{{ __journal_start_time }}" --no-pager |
+        grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:storage" ||
+        { echo ERROR: BEGIN fingerprint not found; exit 1; };
+        journalctl --since "{{ __journal_start_time }}" --no-pager |
+        grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:storage" ||
+        { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+      changed_when: false


### PR DESCRIPTION
Feature: Add role fingerprint to system journal as the first task in the role.

Reason: The journal is often exported to reporting systems making it easy to
tell if the role is being used, and when.

Result: Users can get information in their reporting and log aggregation systems
of role usage.

## Summary by Sourcery

Add a custom fingerprinting mechanism that logs role begin and success markers to the system journal for the storage system role.

New Features:
- Introduce an sr_fingerprint Ansible module to write timestamped fingerprint messages to the system log.
- Record begin and success fingerprint messages for the storage role execution, including Ansible and OS version metadata.

Tests:
- Extend default role test playbook to capture start time and verify presence of begin and success fingerprints in the system journal.