### PR TITLE
test: add role fingerprints to syslog

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,21 +2,30 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   tasks:
+    - name: See if /dev/log exists for the fingerprint check
+      stat:
+        path: /dev/log
+      register: __register_dev_log
+
     - name: Set the start time for the journal search
       set_fact:
         __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+      when: __register_dev_log.stat.exists
 
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
 
     # look for the exact module invocation, not some other message that might contain the string
     - name: Check system journal contains role fingerprints
-      shell: >-
-        set -eo pipefail;
-        journalctl --since "{{ __journal_start_time }}" --no-pager |
-        grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:storage" ||
-        { echo ERROR: BEGIN fingerprint not found; exit 1; };
-        journalctl --since "{{ __journal_start_time }}" --no-pager |
-        grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:storage" ||
-        { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+      shell:
+        executable: /bin/bash
+        cmd: >-
+          set -eo pipefail;
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:storage" ||
+          { echo ERROR: BEGIN fingerprint not found; exit 1; };
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:storage" ||
+          { echo ERROR: SUCCESS fingerprint not found; exit 1; }
       changed_when: false
+      when: __register_dev_log.stat.exists


### PR DESCRIPTION
Test updates based on testing with bootc and on other platforms.

## Summary by Sourcery

Guard syslog fingerprint verification in the default role test so it only runs when the system journal socket is present, and standardize the shell invocation to use bash.

Tests:
- Update the default role test to stat /dev/log and conditionally run journal fingerprint checks based on its presence.
- Adjust the journal fingerprint shell task to explicitly use /bin/bash for execution.