### PR TITLE
test: refactor test setup to add device info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,21 +6,12 @@ galaxy_info:
   license: MIT
   min_ansible_version: "2.9"
   platforms:
-    - name: Fedora
-      versions:
-        - all
     - name: EL
       versions:
-        - "7"
         - "8"
-        - "9"
   galaxy_tags:
     - centos
-    - el7
     - el8
-    - el9
-    - el10
-    - fedora
     - lvm
     - redhat
     - rhel

--- a/tasks/stat_device.yml
+++ b/tasks/stat_device.yml
@@ -1,5 +1,0 @@
----
-- name: Stat the final device file
-  stat:
-    path: "{{ volume._device }}"
-  register: device_status

--- a/tests/tasks/get_unused_disk.yml
+++ b/tests/tasks/get_unused_disk.yml
@@ -15,11 +15,11 @@
 
 - name: Find unused disks in the system
   find_unused_disk:
-    min_size: "{{ min_size | d(omit) }}"
-    max_size: "{{ max_size | d(omit) }}"
-    max_return: "{{ max_return | d(omit) }}"
+    min_size: "{{ min_size | d(__storage_min_size | d(omit)) }}"
+    max_size: "{{ max_size | d(__storage_max_size | d(omit)) }}"
+    max_return: "{{ max_return | d(__storage_max_return | d(omit)) }}"
     with_interface: "{{ storage_test_use_interface | d(omit) }}"
-    match_sector_size: "{{ match_sector_size | d(omit) }}"
+    match_sector_size: "{{ match_sector_size | d(__storage_match_sector_size | d(omit)) }}"
   register: unused_disks_return
 
 - name: Debug why there are no unused disks

--- a/tests/tasks/setup.yml
+++ b/tests/tasks/setup.yml
@@ -1,0 +1,83 @@
+---
+# Single storage test setup entrypoint (typically the play's first task).
+#
+# Optional variables:
+#   __storage_include_prep — default true: run role with no storage_* config and set
+#     storage_skip_checks. Set false for a follow-up include that only needs
+#     package_facts / blivet facts (e.g. tests_resize.yml after initial setup).
+#   __storage_storage_skip_checks — if set, used as storage_skip_checks instead of
+#     the default [blivet_available, packages_installed conditional].
+#   __storage_get_package_facts — default false: ansible.builtin.package_facts, then
+#     blivet_pkg_version, and is_fedora / is_rhel* / is_rhel78.
+#   __storage_get_unused_disks — default true: whether to include get_unused_disk.yml.
+#     The playbook supplies this when needed; setup does not derive it.
+#   __storage_min_size, __storage_max_return, __storage_max_size,
+#   __storage_disks_needed, __storage_match_sector_size — passed to get_unused_disk.
+#
+- name: Run the role
+  when: __storage_include_prep | default(true)
+  block:
+    - name: Run the role
+      ansible.builtin.include_tasks: run_role_with_clear_facts.yml
+
+    - name: Mark tasks to be skipped
+      ansible.builtin.set_fact:
+        storage_skip_checks: >-
+          {{
+            __storage_storage_skip_checks
+            if __storage_storage_skip_checks is defined
+            else (
+              ['blivet_available',
+              (lookup('env', 'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false'])
+              | ternary('packages_installed', '')]
+            )
+          }}
+
+- name: Gather package facts and set vars based on package facts
+  when: __storage_get_package_facts | default(false)
+  block:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+      no_log: "{{ ansible_verbosity < 3 }}"
+
+    - name: Set blivet package version
+      ansible.builtin.set_fact:
+        blivet_pkg_version: "{{
+          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
+          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
+      vars:
+        blivet_pkg_name: "{{ ansible_facts.packages |
+          select('search', 'blivet') | select('search', 'python') | list }}"
+
+- name: Set distribution version flags
+  ansible.builtin.set_fact:
+    is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
+    is_rhel7: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7' }}"
+    is_rhel8: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8' }}"
+    is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '9' }}"
+    is_rhel10: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '10' }}"
+    is_rhel78: "{{ ansible_facts['os_family'] == 'RedHat' and
+                   ansible_facts['distribution_major_version'] in ['7', '8'] }}"
+
+- name: Get unused disks for test
+  when: __storage_get_unused_disks | default(true)
+  ansible.builtin.include_tasks: get_unused_disk.yml
+
+- name: Get info about storage devices
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -euxo pipefail
+      exec 1>&2
+      lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE,LOG-SEC
+      if type -p mdadm >/dev/null; then
+        mdadm --misc --examine --scan
+      fi
+      if type -p dmsetup >/dev/null; then
+        dmsetup ls --tree --separator /
+      fi
+      if type -p lvm >/dev/null; then
+        lvm vgdisplay
+      fi
+      udevadm settle -t 0
+  changed_when: false

--- a/tests/tasks/setup.yml
+++ b/tests/tasks/setup.yml
@@ -1,0 +1,89 @@
+---
+# Single storage test setup entrypoint (typically the play's first task).
+#
+# Optional variables:
+#   __storage_include_prep — default true: run role with no storage_* config and set
+#     storage_skip_checks. Set false for a follow-up include that only needs
+#     package_facts / blivet facts (e.g. tests_resize.yml after initial setup).
+#   __storage_storage_skip_checks — if set, used as storage_skip_checks instead of
+#     the default [blivet_available, packages_installed conditional].
+#   __storage_get_package_facts — default false: ansible.builtin.package_facts, then
+#     blivet_pkg_version, and is_fedora / is_rhel* / is_rhel78.
+#   __storage_get_unused_disks — default true: whether to include get_unused_disk.yml.
+#     The playbook supplies this when needed; setup does not derive it.
+#   __storage_min_size, __storage_max_return, __storage_max_size,
+#   __storage_disks_needed, __storage_match_sector_size — passed to get_unused_disk.
+#
+- name: Run the role
+  when: __storage_include_prep | default(true)
+  block:
+    - name: Run the role
+      ansible.builtin.include_tasks: run_role_with_clear_facts.yml
+
+    - name: Mark tasks to be skipped
+      ansible.builtin.set_fact:
+        storage_skip_checks: >-
+          {{
+            __storage_storage_skip_checks
+            if __storage_storage_skip_checks is defined
+            else (
+              ['blivet_available',
+              (lookup('env', 'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false'])
+              | ternary('packages_installed', '')]
+            )
+          }}
+
+- name: Gather package facts and set vars based on package facts
+  when: __storage_get_package_facts | default(false)
+  vars:
+    blivet_pkg_name: "{{ (ansible_facts.packages | default({})).keys() | select('search', 'blivet') |
+      select('search', 'python') | list | first | default('') }}"
+  block:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+      no_log: "{{ ansible_verbosity < 3 }}"
+      when: blivet_pkg_name | length == 0
+
+    - name: Set blivet package version
+      ansible.builtin.set_fact:
+        blivet_pkg_version: "{{
+          ansible_facts.packages[blivet_pkg_name][0]['version'] +
+          '-' + ansible_facts.packages[blivet_pkg_name][0]['release'] }}"
+
+- name: Set distribution version flags
+  ansible.builtin.set_fact:
+    is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
+    is_rhel7: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7' }}"
+    is_rhel8: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8' }}"
+    is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '9' }}"
+    is_rhel10: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '10' }}"
+    is_rhel78: "{{ ansible_facts['os_family'] == 'RedHat' and
+                   ansible_facts['distribution_major_version'] in ['7', '8'] }}"
+
+- name: Get unused disks for test
+  when: __storage_get_unused_disks | default(true)
+  ansible.builtin.include_tasks: get_unused_disk.yml
+
+# This is primarily for debugging purposes
+- name: Get info about storage devices
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -euxo pipefail
+      exec 1>&2
+      if type -p lsblk >/dev/null; then
+        lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE,LOG-SEC
+      fi
+      if type -p mdadm >/dev/null; then
+        mdadm --misc --examine --scan
+      fi
+      if type -p dmsetup >/dev/null; then
+        dmsetup ls --tree --separator /
+      fi
+      if type -p lvm >/dev/null; then
+        lvm vgdisplay
+      fi
+      if type -p udevadm >/dev/null; then
+        udevadm settle -t 0
+      fi
+  changed_when: false

--- a/tests/tests_change_disk_fs.yml
+++ b/tests/tests_change_disk_fs.yml
@@ -10,23 +10,11 @@
       if (ansible_facts['distribution'] == 'RedHat' and
           ansible_facts['distribution_major_version'] == '6')
       else 'ext4' }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a disk device with the default file system type
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_change_disk_mount.yml
+++ b/tests/tests_change_disk_mount.yml
@@ -6,6 +6,8 @@
     mount_location_before: '/opt/test1'
     mount_location_after: '/opt/test2'
     volume_size: '5g'
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
 
   tasks:
     - name: Create blockdev and loop mount
@@ -19,22 +21,8 @@
         cat /proc/mounts | grep loop
       changed_when: false
 
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a disk device mounted at "{{ mount_location_before }}"
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_change_fs.yml
+++ b/tests/tests_change_fs.yml
@@ -9,26 +9,14 @@
     fs_after: "{{ (ansible_facts['distribution'] == 'RedHat' and
                    ansible_facts['distribution_major_version'] == '6') |
                   ternary('ext4', 'xfs') }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a LVM logical volume with default fs_type
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_change_fs_use_partitions.yml
+++ b/tests/tests_change_fs_use_partitions.yml
@@ -11,25 +11,13 @@
       if (ansible_facts['distribution'] == 'RedHat' and
           ansible_facts['distribution_major_version'] == '6')
       else 'ext4' }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create an LVM partition with the default file system type
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_change_mount.yml
+++ b/tests/tests_change_mount.yml
@@ -6,26 +6,14 @@
     mount_location_before: '/opt/test1'
     mount_location_after: '/opt/test2'
     volume_size: '3g'
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a LVM logical volume mounted at {{ mount_location_before }}
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_disk_then_remove.yml
+++ b/tests/tests_create_disk_then_remove.yml
@@ -5,23 +5,11 @@
   vars:
     storage_safe_mode: false
     mount_location: '/opt/test1'
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: >-
         Create a disk device; specify disks as non-list mounted on

--- a/tests/tests_create_lv_size_equal_to_vg.yml
+++ b/tests/tests_create_lv_size_equal_to_vg.yml
@@ -7,26 +7,14 @@
     mount_location: '/opt/test1'
     volume_group_size: '10g'
     lv_size: '10g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create one lv which size is equal to vg size
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_lvm_cache_then_remove.yml
+++ b/tests/tests_create_lvm_cache_then_remove.yml
@@ -8,52 +8,18 @@
     volume_group_size: '10g'
     volume_size: '5g'
     cache_size: '4g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 2
+    __storage_disks_needed: 2
+    __storage_match_sector_size: true
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Gather package facts
-      package_facts:
-
-    - name: Set blivet package name
-      set_fact:
-        blivet_pkg_name: "{{ ansible_facts.packages |
-          select('search', 'blivet') | select('search', 'python') | list }}"
-
-    - name: Set blivet package version
-      set_fact:
-        blivet_pkg_version: "{{
-          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-    - name: Set distribution version
-      set_fact:
-        is_rhel10: "{{ (ansible_facts['os_family'] == 'RedHat') and
-          ansible_facts.distribution_major_version == '10' }}"
-        is_rhel9: "{{ (ansible_facts['os_family'] == 'RedHat') and
-          ansible_facts.distribution_major_version == '9' }}"
-        is_rhel8: "{{ (ansible_facts['os_family'] == 'RedHat') and
-          ansible_facts.distribution_major_version == '8' }}"
-        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
       vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 2
-        disks_needed: 2
-        match_sector_size: true
+        __storage_get_package_facts: true
 
     - name: Create a cached LVM logical volume under volume group 'foo'
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_lvm_pool_then_remove.yml
+++ b/tests/tests_create_lvm_pool_then_remove.yml
@@ -9,26 +9,14 @@
     volume_group_size: '10g'
     volume1_size: '5g'
     volume2_size: '4g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create two LVM logical volumes under volume group 'foo'
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_lvmvdo_then_remove.yml
+++ b/tests/tests_create_lvmvdo_then_remove.yml
@@ -13,58 +13,39 @@
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
+      vars:
+        __storage_storage_skip_checks:
           - blivet_available
-
-    - name: Gather package facts
-      package_facts:
-
-    - name: Set blivet package name
-      set_fact:
-        blivet_pkg_name: "{{ ansible_facts.packages |
-          select('search', 'blivet') | select('search', 'python') | list }}"
-
-    - name: Set blivet package version
-      set_fact:
-        blivet_pkg_version: "{{
-          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-    - name: Set libblockdev package version
-      set_fact:
-        libblockdev_pkg_version: "{{
-          ansible_facts.packages['libblockdev'][0]['version'] +
-          '-' + ansible_facts.packages['libblockdev'][0]['release'] }}"
+        __storage_get_package_facts: true
+        __storage_get_unused_disks: false
 
     - name: Check if kvdo is loadable
-      command: modprobe --dry-run kvdo
+      ansible.builtin.command: modprobe --dry-run kvdo
       ignore_errors: true  # noqa ignore-errors
       changed_when: false
       register: __storage_kvdo_loadable
 
     - name: Check if dm-vdo is loadable
-      command: modprobe --dry-run dm-vdo
+      ansible.builtin.command: modprobe --dry-run dm-vdo
       ignore_errors: true  # noqa ignore-errors
       changed_when: false
       register: __storage_dmvdo_loadable
 
-    - name: Set flag for Fedora
-      set_fact:
-        is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
+    - name: Set libblockdev package version
+      ansible.builtin.set_fact:
+        libblockdev_pkg_version: "{{
+          ansible_facts.packages['libblockdev'][0]['version'] +
+          '-' + ansible_facts.packages['libblockdev'][0]['release'] }}"
 
     - name: Run tests if VDO is available
-      when:
-        - blivet_pkg_version is version("3.2.2-10", ">=")
-        - not is_fedora or libblockdev_pkg_version is version("3.1.1-2", ">=")
-        - __storage_kvdo_loadable is success or __storage_dmvdo_loadable is success
+      when: (blivet_pkg_version is defined and blivet_pkg_version is version("3.2.2-10", ">="))
+            and (not is_fedora or libblockdev_pkg_version is version("3.1.1-2", ">="))
+            and (__storage_kvdo_loadable is success or __storage_dmvdo_loadable is success)
       block:
-        - name: Get unused disks
-          include_tasks: get_unused_disk.yml
+        - name: Collect unused disks for VDO test
+          ansible.builtin.include_tasks: tasks/get_unused_disk.yml
           vars:
             min_size: "{{ volume_group_size }}"
             max_return: 1

--- a/tests/tests_create_multiple_partitions_dos.yml
+++ b/tests/tests_create_multiple_partitions_dos.yml
@@ -8,23 +8,11 @@
     volume2_size: '3g'
     volume3_size: '1g'
     storage_disklabel_type: 'msdos'
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Try to create mounted extended partition (expect failure)
       include_tasks: verify-role-failed.yml

--- a/tests/tests_create_multiple_partitions_gpt.yml
+++ b/tests/tests_create_multiple_partitions_gpt.yml
@@ -8,23 +8,11 @@
     volume2_size: '2g'
     volume3_size: '2g'
     storage_disklabel_type: 'gpt'
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create two partitions
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_partition_volume_then_remove.yml
+++ b/tests/tests_create_partition_volume_then_remove.yml
@@ -5,23 +5,11 @@
   vars:
     storage_safe_mode: false
     mount_location: '/opt/test1'
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a partition device mounted on {{ mount_location }}
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -11,50 +11,16 @@
     volume1_size: '2g'
     volume3_size: '3g'
     volume2_size: '3g'
+    __storage_max_return: 2
+    __storage_disks_needed: 2
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Gather package facts
-      package_facts:
-
-    - name: Set blivet package name
-      set_fact:
-        blivet_pkg_name: "{{ ansible_facts.packages |
-          select('search', 'blivet') | select('search', 'python') | list }}"
-
-    - name: Set blivet package version
-      set_fact:
-        blivet_pkg_version: "{{
-          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-    - name: Set distribution version
-      set_fact:
-        is_rhel10: "{{ (ansible_facts['os_family'] == 'RedHat') and
-          ansible_facts.distribution_major_version == '10' }}"
-        is_rhel9: "{{ (ansible_facts['os_family'] == 'RedHat') and
-          ansible_facts.distribution_major_version == '9' }}"
-        is_rhel8: "{{ (ansible_facts['os_family'] == 'RedHat') and
-          ansible_facts.distribution_major_version == '8' }}"
-        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
       vars:
-        max_return: 2
-        disks_needed: 2
+        __storage_get_package_facts: true
 
     - name: Create a RAID0 device
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -254,6 +254,19 @@
     - name: Verify role results - 12
       include_tasks: verify-role-results.yml
 
+    - name: Debug0
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -euxo pipefail
+          exec 1>&2
+          lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE,LOG-SEC
+          mdadm --misc --examine --scan
+          dmsetup ls --tree --separator /
+          lvm vgdisplay
+          cat /proc/mdstat
+      changed_when: false
+
     - name: Remove the device created above - 5
       include_tasks: tasks/run_role_with_clear_facts.yml
       vars:

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -6,24 +6,12 @@
     storage_safe_mode: false
     storage_use_partitions: true
     mount_location: '/opt/test1'
+    __storage_max_return: 2
+    __storage_disks_needed: 2
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 2
-        disks_needed: 2
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a RAID0 device mounted on {{ mount_location }}
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_create_thinp_then_remove.yml
+++ b/tests/tests_create_thinp_then_remove.yml
@@ -10,15 +10,11 @@
     mount_location3: '/opt/test3'
     volume1_size: '3g'
     volume2_size: '4g'
+    __storage_max_return: 3
+    __storage_match_sector_size: true
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 3
-        match_sector_size: true
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a thinpool device
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_disk_errors.yml
+++ b/tests/tests_disk_errors.yml
@@ -5,25 +5,13 @@
   vars:
     mount_location: '/opt/test1'
     testfile: "{{ mount_location }}/quux"
+    __storage_min_size: "10g"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "10g"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Verify that the role fails when no disks are specified
       include_tasks: verify-role-failed.yml

--- a/tests/tests_existing_lvm_pool.yml
+++ b/tests/tests_existing_lvm_pool.yml
@@ -7,26 +7,14 @@
     volume_group_size: '5g'
     volume_size: '4g'
     pool_name: foo
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create one LVM logical volume under one volume group
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_fatals_cache_volume.yml
+++ b/tests/tests_fatals_cache_volume.yml
@@ -7,27 +7,15 @@
     volume_group_size: '10g'
     volume_size: '5g'
     cache_size: '4g'
+    __storage_max_return: 2
+    __storage_disks_needed: 2
+    __storage_match_sector_size: true
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 2
-        disks_needed: 2
-        match_sector_size: true
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Verify that creating a cached partition volume fails
       include_tasks: verify-role-failed.yml

--- a/tests/tests_fatals_raid_pool.yml
+++ b/tests/tests_fatals_raid_pool.yml
@@ -11,26 +11,14 @@
     volume1_size: '2g'
     volume3_size: '3g'
     volume2_size: '3g'
+    __storage_max_return: 2
+    __storage_disks_needed: 2
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 2
-        disks_needed: 2
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Try to create a raid pool with invalid raid_level (expect failure)
       include_tasks: verify-role-failed.yml

--- a/tests/tests_fatals_raid_volume.yml
+++ b/tests/tests_fatals_raid_volume.yml
@@ -6,24 +6,12 @@
     storage_safe_mode: false
     storage_use_partitions: true
     mount_location: '/opt/test1'
+    __storage_max_return: 2
+    __storage_disks_needed: 2
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 2
-        disks_needed: 2
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Try to create a raid pool with invalid raid_level (expect failure)
       include_tasks: verify-role-failed.yml

--- a/tests/tests_filesystem_one_disk.yml
+++ b/tests/tests_filesystem_one_disk.yml
@@ -4,23 +4,11 @@
   become: true
   vars:
     mount_location: '/opt/test1'
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Initialize a disk device with the default fs type
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_luks.yml
+++ b/tests/tests_luks.yml
@@ -9,6 +9,8 @@
     __luks_cipher: "{{ (__luks_cipher_env == '') |
       ternary('aes-xts-plain64', __luks_cipher_env) }}"
     __luks_cipher_env: "{{ lookup('env', 'SYSTEM_ROLES_LUKS_CIPHER') }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
@@ -71,14 +73,8 @@
           reboot:
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     ##
     ## Disk

--- a/tests/tests_luks2.yml
+++ b/tests/tests_luks2.yml
@@ -9,6 +9,8 @@
     __luks_cipher: "{{ (__luks_cipher_env == '') |
       ternary('aes-xts-plain64', __luks_cipher_env) }}"
     __luks_cipher_env: "{{ lookup('env', 'SYSTEM_ROLES_LUKS_CIPHER') }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
@@ -71,14 +73,8 @@
           reboot:
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     ##
     ## Disk

--- a/tests/tests_luks_pool.yml
+++ b/tests/tests_luks_pool.yml
@@ -11,6 +11,8 @@
     __luks_cipher: "{{ (__luks_cipher_env == '') |
       ternary('aes-xts-plain64', __luks_cipher_env) }}"
     __luks_cipher_env: "{{ lookup('env', 'SYSTEM_ROLES_LUKS_CIPHER') }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
@@ -55,19 +57,11 @@
           reboot:
             test_command: grep 1 /proc/sys/crypto/fips_enabled
 
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
       vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+        __storage_storage_skip_checks:
+          - blivet_available
 
     ##
     ## LVM Pool

--- a/tests/tests_lvm_auto_size_cap.yml
+++ b/tests/tests_lvm_auto_size_cap.yml
@@ -2,25 +2,14 @@
 - name: Test lvm auto size
   hosts: all
   become: true
+  vars:
+    __storage_min_size: 10g
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: 10g
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Run lsblk -b -l --noheadings -o NAME,SIZE
       command: lsblk -b -l --noheadings -o NAME,SIZE

--- a/tests/tests_lvm_errors.yml
+++ b/tests/tests_lvm_errors.yml
@@ -11,25 +11,13 @@
     invalid_disks:
       - '/non/existent/disk'
     invalid_size: 'xyz GiB'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Test for correct handling of invalid disk specifications.
       include_tasks: verify-role-failed.yml

--- a/tests/tests_lvm_multiple_disks_multiple_volumes.yml
+++ b/tests/tests_lvm_multiple_disks_multiple_volumes.yml
@@ -7,27 +7,15 @@
     mount_location2: '/opt/test2'
     volume_group_size: '5g'
     volume_size: '4g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 2
+    __storage_disks_needed: 2
+    __storage_match_sector_size: true
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 2
-        disks_needed: 2
-        match_sector_size: true
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: >-
         Create a logical volume spanning two physical volumes that changes its

--- a/tests/tests_lvm_one_disk_multiple_volumes.yml
+++ b/tests/tests_lvm_one_disk_multiple_volumes.yml
@@ -5,26 +5,14 @@
   vars:
     volume_group_size: '10g'
     volume_size: '3g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create three LVM logical volumes under one volume group
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_lvm_one_disk_one_volume.yml
+++ b/tests/tests_lvm_one_disk_one_volume.yml
@@ -6,26 +6,14 @@
     mount_location: '/opt/test1'
     volume_group_size: '5g'
     volume_size: '4g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create one LVM logical volume under one volume group
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_lvm_percent_size.yml
+++ b/tests/tests_lvm_percent_size.yml
@@ -11,17 +11,13 @@
     size2: "40%"
     size3: "25%"
     size4: "50%"
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: >-
         Test for correct handling of invalid percentage-based size

--- a/tests/tests_lvm_pool_members.yml
+++ b/tests/tests_lvm_pool_members.yml
@@ -11,50 +11,23 @@
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Gather package facts
-      package_facts:
-
-    - name: Set blivet package name
-      set_fact:
-        blivet_pkg_name: "{{ ansible_facts.packages |
-          select('search', 'blivet') | select('search', 'python') | list }}"
-
-    - name: Set blivet package version
-      set_fact:
-        blivet_pkg_version: "{{
-          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-    - name: Set distribution version flags
-      set_fact:
-        is_rhel10: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '10' }}"
-        is_rhel9: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '9' }}"
-        is_rhel8: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8' }}"
-        is_rhel7: "{{ ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '7' }}"
-        is_fedora: "{{ ansible_facts['distribution'] == 'Fedora' }}"
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
+      vars:
+        __storage_get_package_facts: true
+        __storage_get_unused_disks: false
 
     # end early when running with old blivet where removing PVs from a VG fails
     - name: Run test only if blivet supports this functionality
-      when: (blivet_pkg_version is defined and
-             ((is_fedora and blivet_pkg_version is version("3.4.3-1", ">=")) or
-              (is_rhel7 and blivet_pkg_version is version("3.4.0-10", ">=")) or
-              (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
-              (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">=")) or
-              is_rhel10))
+      when: blivet_pkg_version is defined and
+            ((is_fedora and blivet_pkg_version is version("3.4.3-1", ">=")) or
+             (is_rhel7 and blivet_pkg_version is version("3.4.0-10", ">=")) or
+             (is_rhel8 and blivet_pkg_version is version("3.4.0-10", ">=")) or
+             (is_rhel9 and blivet_pkg_version is version("3.4.0-14", ">=")) or
+             is_rhel10)
       block:
-        - name: Get unused disks
-          include_tasks: get_unused_disk.yml
+        - name: Collect unused disks for pool members test
+          ansible.builtin.include_tasks: tasks/get_unused_disk.yml
           vars:
             min_size: "{{ volume_group_size }}"
             disks_needed: 3

--- a/tests/tests_lvm_pool_pv_grow.yml
+++ b/tests/tests_lvm_pool_pv_grow.yml
@@ -5,29 +5,17 @@
   vars:
     storage_safe_mode: false
     pv_size: '8g'
+    __storage_max_return: 1
+    __storage_min_size: "10g"
   tags:
     - tests::lvm
 
   tasks:
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
+
     - name: Test
       block:
-
-        - name: Run the role
-          include_tasks: tasks/run_role_with_clear_facts.yml
-
-        - name: Mark tasks to be skipped
-          set_fact:
-            storage_skip_checks:
-              - blivet_available
-              - "{{ (lookup('env',
-                            'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                    ternary('packages_installed', '') }}"
-
-        - name: Get unused disks
-          include_tasks: get_unused_disk.yml
-          vars:
-            max_return: 1
-            min_size: "10g"
 
         - name: Create PV with a space to grow
           command: >-

--- a/tests/tests_lvm_pool_shared.yml
+++ b/tests/tests_lvm_pool_shared.yml
@@ -16,6 +16,12 @@
 
     - name: Run the test
       block:
+        - name: Storage test setup
+          ansible.builtin.include_tasks: tasks/setup.yml
+          vars:
+            __storage_get_package_facts: true
+            __storage_get_unused_disks: false
+
         - name: See if lvm.conf exists
           stat:
             path: "{{ lvm_conf }}"
@@ -40,33 +46,6 @@
           set_fact:
             inventory_hostname: "127.0.0.1"  # noqa: var-naming
           when: inventory_hostname == "localhost"
-
-        - name: Run the role to install blivet
-          include_tasks: tasks/run_role_with_clear_facts.yml
-
-        - name: Gather package facts
-          package_facts:
-
-        - name: Set blivet package name
-          set_fact:
-            blivet_pkg_name: "{{ ansible_facts.packages |
-              select('search', 'blivet') | select('search', 'python') | list }}"
-
-        - name: Set blivet package version
-          set_fact:
-            blivet_pkg_version: "{{
-              ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-              '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-        - name: Set distribution version
-          set_fact:
-            is_rhel10: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                        ansible_facts.distribution_major_version == '10' }}"
-            is_rhel9: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                        ansible_facts.distribution_major_version == '9' }}"
-            is_rhel8: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                        ansible_facts.distribution_major_version == '8' }}"
-            is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
         - name: Skip test if the blivet version does not support shared VGs
           meta: end_host
@@ -107,8 +86,8 @@
                   - dlm
                   - lvmlockd
 
-        - name: Get unused disks
-          include_tasks: get_unused_disk.yml
+        - name: Discover unused disks for testing
+          ansible.builtin.include_tasks: tasks/get_unused_disk.yml
           vars:
             max_return: 1
 

--- a/tests/tests_misc.yml
+++ b/tests/tests_misc.yml
@@ -9,25 +9,13 @@
     volume1_size: "4g"
     unused_disk_subfact: "{{ ansible_facts['devices'][unused_disks[0]] }}"
     too_large_size: "{{ (unused_disk_subfact.sectors | int * 1.2) * 512 }}"
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Include the role to ensure packages are installed
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks for test
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Test creating ext4 filesystem with valid parameter "-Fb 4096"
       include_tasks: tasks/run_role_with_clear_facts.yml
@@ -180,14 +168,15 @@
 
     # rhel7 has a limitation of 128g swap size
     - name: Get unused disks for swap
-      include_tasks: get_unused_disk.yml
+      ansible.builtin.include_tasks: tasks/get_unused_disk.yml
       vars:
         min_size: "{{ volume_group_size }}"
         max_return: 1
         disks_needed: 1
-        max_size: "{{ '127g' if (ansible_facts['os_family'] == 'RedHat'
+        max_size: >-
+          {{ '127g' if (ansible_facts['os_family'] == 'RedHat'
           and ansible_facts['distribution_major_version'] is version('8', '<'))
-          else '0' }}"
+          else '0' }}
 
     - name: Save disk used for swap
       set_fact:

--- a/tests/tests_missing_volume_type_in_pool.yml
+++ b/tests/tests_missing_volume_type_in_pool.yml
@@ -5,23 +5,11 @@
   vars:
     storage_safe_mode: false
     mount_location: '/opt/test1'
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a partition device mounted on "{{ mount_location }}"
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_null_raid_pool.yml
+++ b/tests/tests_null_raid_pool.yml
@@ -7,26 +7,14 @@
     storage_use_partitions: true
     mount_location1: '/opt/test1'
     volume1_size: '2g'
+    __storage_max_return: 2
+    __storage_disks_needed: 2
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 2
-        disks_needed: 2
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Get existing raids (before run)
       command: "cat /proc/mdstat"

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -11,26 +11,14 @@
     volume1_size: '2g'
     volume3_size: '3g'
     volume2_size: '3g'
+    __storage_max_return: 3
+    __storage_disks_needed: 3
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 3
-        disks_needed: 3
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a RAID1 device
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_raid_volume_cleanup.yml
+++ b/tests/tests_raid_volume_cleanup.yml
@@ -9,22 +9,16 @@
     mount_location2: '/opt/test2'
     volume1_size: '5g'
     volume2_size: '4g'
+    __storage_max_return: 3
+    __storage_disks_needed: 3
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
+      vars:
+        __storage_storage_skip_checks:
           - blivet_available
           - packages_installed
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 3
-        disks_needed: 3
 
     - name: Create two LVM logical volumes under volume group 'foo'
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -6,24 +6,12 @@
     storage_safe_mode: false
     storage_use_partitions: true
     mount_location: '/opt/test1'
+    __storage_max_return: 3
+    __storage_disks_needed: 3
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 3
-        disks_needed: 3
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a RAID0 device mounted on "{{ mount_location }}"
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_remove_mount.yml
+++ b/tests/tests_remove_mount.yml
@@ -6,26 +6,14 @@
     mount_location_before: '/opt/test1'
     mount_location_after: ''
     volume_size: '3g'
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a LVM logical volume mounted at "{{ mount_location_before }}"
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_remove_nonexistent_pool.yml
+++ b/tests/tests_remove_nonexistent_pool.yml
@@ -7,27 +7,15 @@
     storage_use_partitions: true
     mount_location1: '/opt/test1'
     storage_test_skip_fingerprint: true
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   # This tests the issue when removing nonexistent pool (with listed volumes)
   # caused crash
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Removing nonexistent pool (with listed volumes)
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_resize.yml
+++ b/tests/tests_resize.yml
@@ -15,25 +15,15 @@
     acc_large_size: '{{ unused_disk_subfact.sectors | int * 1.015 * 512 }}'
     acc_small_size: '{{ unused_disk_subfact.sectors | int * 0.985 * 512 }}'
     disk_size: '{{ unused_disk_subfact.sectors | int * 512 }}'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
       vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+        __storage_get_package_facts: true
 
     # For ext4 FS
 
@@ -338,30 +328,6 @@
 
     - name: Verify role results - 14
       include_tasks: verify-role-results.yml
-
-    - name: Gather package facts
-      package_facts:
-
-    - name: Set blivet package name
-      set_fact:
-        blivet_pkg_name: "{{ ansible_facts.packages |
-          select('search', 'blivet') | select('search', 'python') | list }}"
-
-    - name: Set blivet package version
-      set_fact:
-        blivet_pkg_version: "{{
-          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-    - name: Set distribution version
-      set_fact:
-        is_rhel10: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    ansible_facts.distribution_major_version == '10' }}"
-        is_rhel9: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    ansible_facts.distribution_major_version == '9' }}"
-        is_rhel8: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    ansible_facts.distribution_major_version == '8' }}"
-        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
 
     # For ext4 FS -- online resize
     - name: Test ext4 online resize

--- a/tests/tests_safe_mode_check.yml
+++ b/tests/tests_safe_mode_check.yml
@@ -9,26 +9,14 @@
     volume_group_size: '10g'
     volume1_size: '5g'
     volume2_size: '4g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_max_return: 1
   tags:
     - tests::lvm
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_group_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Try to install nilfs2 support
       block:

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -7,55 +7,22 @@
     mount_location_2: '/opt/test2'
     volume_group_size: '5g'
     volume_size: '4g'
+    __storage_min_size: "{{ volume_group_size }}"
+    __storage_disks_needed: 2
   tags:
     - tests::stratis
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Gather package facts
-      package_facts:
-
-    - name: Set blivet package name
-      set_fact:
-        blivet_pkg_name: "{{ ansible_facts.packages |
-          select('search', 'blivet') | select('search', 'python') | list }}"
-
-    - name: Set blivet package version
-      set_fact:
-        blivet_pkg_version: "{{
-          ansible_facts.packages[blivet_pkg_name[0]][0]['version'] +
-          '-' + ansible_facts.packages[blivet_pkg_name[0]][0]['release'] }}"
-
-    - name: Set distribution version
-      set_fact:
-        is_rhel78: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    (ansible_facts.distribution_major_version == '7' or
-                     ansible_facts.distribution_major_version == '8') }}"
-        is_rhel9: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    ansible_facts.distribution_major_version == '9' }}"
-        is_rhel10: "{{ (ansible_facts['os_family'] == 'RedHat') and
-                    ansible_facts.distribution_major_version == '10' }}"
-        is_fedora: "{{ ansible_facts.distribution == 'Fedora' }}"
+    - name: Storage test setup
+      ansible.builtin.include_tasks: tasks/setup.yml
+      vars:
+        __storage_get_package_facts: true
+        # From gather_facts only (safe before setup runs); mirrors is_rhel78 in setup.yml
+        __storage_get_unused_disks: "{{ not (ansible_facts['os_family'] == 'RedHat' and (ansible_facts['distribution_major_version'] == '7' or ansible_facts['distribution_major_version'] == '8')) }}"
 
     - name: Completely skip this on RHEL/CentOS 7 and 8 where Stratis isn't supported by blivet
       when: not is_rhel78
       block:
-        - name: Get unused disks
-          include_tasks: get_unused_disk.yml
-          vars:
-            min_size: "{{ volume_group_size }}"
-            disks_needed: 2
-
         # stratisd is not started automatically and doesn't support DBus activation
         # this will be covered by Blivet in the next build
         - name: Start stratisd service

--- a/tests/tests_swap.yml
+++ b/tests/tests_swap.yml
@@ -7,28 +7,16 @@
     volume_size: '5g'
     __swap_disk: "{{ unused_disks[0] }}"
     __non_swap_disk: "{{ unused_disks[1] }}"
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 2
+    __storage_disks_needed: 2
+    __storage_max_size: >-
+      {{ '127g' if (ansible_facts['os_family'] == 'RedHat'
+      and ansible_facts['distribution_major_version'] is version('8', '<'))
+      else '0' }}
   tasks:
-    - name: Include role to ensure packages are installed
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    # rhel7 has a limitation of 128g swap size
-    - name: Get unused disks for swap
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 2
-        disks_needed: 2
-        max_size: "{{ '127g' if (ansible_facts['os_family'] == 'RedHat'
-          and ansible_facts['distribution_major_version'] is version('8', '<'))
-          else '0' }}"
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Create a disk device with swap
       include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_volume_relabel.yml
+++ b/tests/tests_volume_relabel.yml
@@ -6,24 +6,12 @@
     storage_safe_mode: false
     mount_location: '/opt/test1'
     volume_size: '5g'
+    __storage_min_size: "{{ volume_size }}"
+    __storage_max_return: 1
 
   tasks:
-    - name: Run the role
-      include_tasks: tasks/run_role_with_clear_facts.yml
-
-    - name: Mark tasks to be skipped
-      set_fact:
-        storage_skip_checks:
-          - blivet_available
-          - "{{ (lookup('env',
-                        'SYSTEM_ROLES_REMOVE_CLOUD_INIT') in ['', 'false']) |
-                ternary('packages_installed', '') }}"
-
-    - name: Get unused disks
-      include_tasks: get_unused_disk.yml
-      vars:
-        min_size: "{{ volume_size }}"
-        max_return: 1
+    - name: Prep storage role and discover unused disks
+      ansible.builtin.include_tasks: tasks/setup.yml
 
     - name: Set label
       include_tasks: tasks/run_role_with_clear_facts.yml


### PR DESCRIPTION
Refactor the tests so that we can have a common tests/tasks/setup.yml to handle
common setup tasks as well as print some diagnostic information before each
test run to see if we can solve some of these test flakes.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor storage-related Ansible tests to use a shared setup task file for common preparation and diagnostics.

Tests:
- Introduce a shared tests/tasks/setup.yml to centralize storage test preparation, including role invocation, skip checks, package/distro facts, unused disk discovery, and device diagnostics.
- Update all storage-focused test playbooks to use the shared setup task with configurable __storage_* variables for disk selection and environment conditions.
- Move and generalize get_unused_disk task into tests/tasks/get_unused_disk.yml so it can consume the shared __storage_* parameters across tests.