### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -91,6 +91,7 @@
   block:
     - name: Get service facts
       service_facts:
+      no_log: "{{ ansible_verbosity < 2 }}"
       when:
         - not "services" in ansible_facts
         - not "cryptsetup_services" in storage_skip_checks | d([])


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like service_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - service_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Hide service_facts output from logs by default and only show it when Ansible verbosity is set to -vv or higher.