### PR TITLE
docs(changelog): version 1.21.1 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+[1.21.1] - 2026-05-07
+--------------------
+
+### Bug Fixes
+
+- fix: add verbosity-based no_log to facts modules (#619)
+
+### Other Changes
+
+- test: refactor test setup to add device info (#617)
+- ci: Bump actions/github-script from 8 to 9 (#618)
+
 [1.21.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.21.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update changelog for the 1.21.1 release with notes on bug fixes, test refactors, and CI changes.

Bug Fixes:
- Document fix adding verbosity-based no_log handling to facts modules.

Enhancements:
- Document test setup refactor to include device info in tests.

CI:
- Document CI change bumping actions/github-script from v8 to v9.

Documentation:
- Add 1.21.1 release section to CHANGELOG.md.