### PR TITLE
fix: only install stratis if requested

### DIFF
--- a/README-ostree.md
+++ b/README-ostree.md
@@ -6,6 +6,10 @@ role cannot install packages. Instead, it will just verify that the necessary
 packages and any other `/usr` files are pre-installed. The role will change the
 package manager to one that is compatible with `rpm-ostree` systems.
 
+If you are not managing stratis pools or volumes, remove `stratisd` and
+`stratis-cli` from the ostree image package list generated from
+`.ostree/get_ostree_data.sh`.
+
 ## Building
 
 To build an ostree image for a particular operating system distribution and

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -59,7 +59,7 @@
 
 - name: Make sure required packages are installed
   package:
-    name: "{{ package_info.packages + extra_pkgs }}"
+    name: "{{ package_info.packages + extra_pkgs + stratis_packages }}"
     state: present
     use: "{{ (__storage_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
@@ -72,6 +72,14 @@
     # into blivet, or made conditional
     extra_pkgs:
       - kpartx
+    stratis_packages: "{{ __storage_manage_stratis | ternary(__storage_stratis_packages, []) }}"
+
+- name: Ensure stratisd is running and enabled
+  service:
+    name: stratisd
+    state: started
+    enabled: true
+  when: __storage_manage_stratis
 
 - name: Manage storage devices and check for errors
   vars:

--- a/tests/tests_stratis.yml
+++ b/tests/tests_stratis.yml
@@ -18,17 +18,15 @@
       vars:
         __storage_get_package_facts: true
         # From gather_facts only (safe before setup runs); mirrors is_rhel78 in setup.yml
-        __storage_get_unused_disks: "{{ not (ansible_facts['os_family'] == 'RedHat' and (ansible_facts['distribution_major_version'] == '7' or ansible_facts['distribution_major_version'] == '8')) }}"
+        __storage_get_unused_disks: "{{ not is_rhel78 }}"
+        __sr_public: true
 
     - name: Completely skip this on RHEL/CentOS 7 and 8 where Stratis isn't supported by blivet
       when: not is_rhel78
       block:
-        # stratisd is not started automatically and doesn't support DBus activation
-        # this will be covered by Blivet in the next build
-        - name: Start stratisd service
-          service:
-            name: stratisd
-            state: started
+        - name: Ensure role will install stratis packages if needed
+          set_fact:
+            storage_skip_checks: "{{ storage_skip_checks | reject('match', '^packages_installed$') }}"
 
         - name: One pool/volume test
           block:
@@ -246,3 +244,14 @@
 
             - name: Verify role results - 12
               include_tasks: verify-role-results.yml
+      always:
+        - name: Ensure stratisd is stopped and disabled
+          service:
+            name: stratisd
+            state: stopped
+            enabled: false
+
+        - name: Remove stratis packages
+          package:
+            name: "{{ __storage_stratis_packages }}"
+            state: absent

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -7,8 +7,6 @@ blivet_package_list:
   - libblockdev-lvm
   - libblockdev-mdraid
   - libblockdev-swap
-  - stratisd
-  - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/OracleLinux_9.yml
+++ b/vars/OracleLinux_9.yml
@@ -9,8 +9,6 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
-  - stratisd
-  - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -8,8 +8,6 @@ blivet_package_list:
   - libblockdev-mdraid
   - libblockdev-swap
   - xfsprogs
-  - stratisd
-  - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -9,8 +9,6 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
-  - stratisd
-  - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -9,8 +9,6 @@ blivet_package_list:
   - vdo
   - kmod-kvdo
   - xfsprogs
-  - stratisd
-  - stratis-cli
   # XXX libblockdev-s390 is available only on s390 so just add 'libblockdev' everywhere
   # else, it is already brought in as dependency of blivet so it's just no-op here
   - "{{ 'libblockdev-s390' if ansible_facts['architecture'] == 's390x' else 'libblockdev' }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,6 +18,15 @@ __storage_required_facts_subsets: "{{ ['!all', '!min', 'devices'] +
 __storage_uses_kmod_kvdo: "{{ __storage_is_rh_distro and
   ansible_facts['distribution_major_version'] | int < 10 }}"
 
+__storage_stratis_packages:
+  - stratisd
+  - stratis-cli
+
+# True when role variables request Stratis pool or volume management
+__storage_manage_stratis: "{{ (storage_pool_defaults.type | default('lvm')) == 'stratis' or (storage_volume_defaults.type | default('lvm')) == 'stratis' or
+  (storage_pools | default([]) | selectattr('type', 'defined') | selectattr('type', 'match', '^stratis$') | list | length > 0) or
+  (storage_volumes | default([]) | selectattr('type', 'defined') | selectattr('type', 'match', '^stratis$') | list | length > 0) }}"
+
 # BEGIN - DO NOT EDIT THIS BLOCK - rh distros variables
 # Ansible distribution identifiers that the role treats like RHEL
 __storage_rh_distros:


### PR DESCRIPTION
Cause: stratis packages are always installed, and the daemon is always started,
even if the user does not use stratis.

Consequence: The system has unnecessary packages and services.
To maintain a good security posture, no services should be installed
and running if not required.

Fix: Change the code so that stratis packages and services are deployed
only if the user is managing stratis.

Result: The storage role does not install unnecessary packages.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional Stratis management: Stratis packages are installed and the stratisd service started/enabled only when Stratis pools/volumes are configured.

* **Documentation**
  * Guidance added to omit Stratis packages from ostree images if not managing Stratis.

* **Tests**
  * Storage tests updated for Stratis enablement flags and now include cleanup to stop/disable and remove Stratis.

* **Chores**
  * Removed Stratis packages from distro package lists and added role variables to manage Stratis packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->