### PR TITLE
test: add debugging for raid tests

### DIFF
--- a/tests/tasks/debug.yml
+++ b/tests/tasks/debug.yml
@@ -20,9 +20,7 @@
       if type -p udevadm >/dev/null; then
         udevadm settle -t 0
       fi
-      if ! type -p lsof >/dev/null; then
-        dnf -y install lsof
-      fi
+      dnf -y install lsof
       ls -alrtFR /dev/md*
       mdadm -v --misc --examine --scan | while read -r array dev other; do
         if [[ "$dev" =~ ^/dev ]]; then

--- a/tests/tasks/debug.yml
+++ b/tests/tasks/debug.yml
@@ -23,8 +23,7 @@
       if ! type -p lsof >/dev/null; then
         dnf -y install lsof
       fi
-      lsof /dev/md* || :
-      ls -alrtFR /dev/md* || :
+      ls -alrtFR /dev/md*
       mdadm -v --misc --examine --scan | while read -r array dev other; do
         if [[ "$dev" =~ ^/dev ]]; then
           mdadm --detail "$dev"

--- a/tests/tasks/debug.yml
+++ b/tests/tasks/debug.yml
@@ -20,12 +20,18 @@
       if type -p udevadm >/dev/null; then
         udevadm settle -t 0
       fi
+      if ! type -p lsof >/dev/null; then
+        dnf -y install lsof
+      fi
+      lsof /dev/md* || :
       ls -alrtFR /dev/md* || :
       mdadm -v --misc --examine --scan | while read -r array dev other; do
         if [[ "$dev" =~ ^/dev ]]; then
           mdadm --detail "$dev"
+          lsof | grep /dev/md
         fi
       done
+      mount
       lvs -a -o name,vgname,segtype,attr,copy_percent,lv_health_status,devices
       pvs -o pv_name,lv_initial_image_sync,lv_image_synced,raid_mismatch_count,raid_sync_action,raid_write_behind,\
       raid_min_recovery_rate,raid_max_recovery_rate,\

--- a/tests/tasks/debug.yml
+++ b/tests/tasks/debug.yml
@@ -1,0 +1,35 @@
+---
+- name: Gather debug information
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -euxo pipefail
+      exec 1>&2
+      if type -p lsblk >/dev/null; then
+        lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE,LOG-SEC
+      fi
+      if type -p mdadm >/dev/null; then
+        mdadm --misc --examine --scan
+      fi
+      if type -p dmsetup >/dev/null; then
+        dmsetup ls --tree --separator /
+      fi
+      if type -p lvm >/dev/null; then
+        lvm vgdisplay
+      fi
+      if type -p udevadm >/dev/null; then
+        udevadm settle -t 0
+      fi
+      ls -alrtFR /dev/md* || :
+      { mdadm -v --misc --examine --scan || : ; } | while read -r array dev other; do
+        if [[ "$dev" =~ ^/dev ]]; then
+          mdadm --detail "$dev"
+        fi
+      done
+      pvs -o pv_name,lv_initial_image_sync,lv_image_synced,raid_mismatch_count,raid_sync_action,raid_write_behind,\
+        raid_min_recovery_rate,raid_max_recovery_rate,\
+        raidintegritymode,raidintegrityblocksize,copy_percent,sync_percent,stripes,data_stripes,region_size
+      lvs -o lv_name,lv_path,lv_initial_image_sync,lv_image_synced,raid_mismatch_count,raid_sync_action,raid_write_behind,\
+        raid_min_recovery_rate,raid_max_recovery_rate,\
+        raidintegritymode,raidintegrityblocksize,copy_percent,sync_percent,stripes,data_stripes,region_size
+  changed_when: false

--- a/tests/tasks/debug.yml
+++ b/tests/tasks/debug.yml
@@ -3,7 +3,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      set -euxo pipefail
+      set -uxo pipefail
       exec 1>&2
       if type -p lsblk >/dev/null; then
         lsblk -p --pairs --bytes -o NAME,TYPE,SIZE,FSTYPE,LOG-SEC
@@ -21,15 +21,18 @@
         udevadm settle -t 0
       fi
       ls -alrtFR /dev/md* || :
-      { mdadm -v --misc --examine --scan || : ; } | while read -r array dev other; do
+      mdadm -v --misc --examine --scan | while read -r array dev other; do
         if [[ "$dev" =~ ^/dev ]]; then
           mdadm --detail "$dev"
         fi
       done
+      lvs -a -o name,vgname,segtype,attr,copy_percent,lv_health_status,devices
       pvs -o pv_name,lv_initial_image_sync,lv_image_synced,raid_mismatch_count,raid_sync_action,raid_write_behind,\
-        raid_min_recovery_rate,raid_max_recovery_rate,\
-        raidintegritymode,raidintegrityblocksize,copy_percent,sync_percent,stripes,data_stripes,region_size
+      raid_min_recovery_rate,raid_max_recovery_rate,\
+      raidintegritymode,raidintegrityblocksize,copy_percent,sync_percent,stripes,data_stripes,region_size
       lvs -o lv_name,lv_path,lv_initial_image_sync,lv_image_synced,raid_mismatch_count,raid_sync_action,raid_write_behind,\
-        raid_min_recovery_rate,raid_max_recovery_rate,\
-        raidintegritymode,raidintegrityblocksize,copy_percent,sync_percent,stripes,data_stripes,region_size
+      raid_min_recovery_rate,raid_max_recovery_rate,\
+      raidintegritymode,raidintegrityblocksize,copy_percent,sync_percent,stripes,data_stripes,region_size
+      cat /tmp/blivet.log
+      cat /tmp/lvm.log
   changed_when: false

--- a/tests/tests_create_raid_pool_then_remove.yml
+++ b/tests/tests_create_raid_pool_then_remove.yml
@@ -17,268 +17,137 @@
     - tests::lvm
 
   tasks:
-    - name: Storage test setup
-      ansible.builtin.include_tasks: tasks/setup.yml
-      vars:
-        __storage_get_package_facts: true
-
-    - name: Create a RAID0 device
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: "raid0"
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: lv2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
-              - name: lv3
-                size: "{{ volume3_size }}"
-                mount_point: "{{ mount_location3 }}"
-
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
-
-    - name: Repeat the previous invocation to verify idempotence
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: "raid0"
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: lv2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
-              - name: lv3
-                size: "{{ volume3_size }}"
-                mount_point: "{{ mount_location3 }}"
-
-    - name: Verify role results - 2
-      include_tasks: verify-role-results.yml
-
-    - name: Remove the device created above
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: raid0
-            state: absent
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: lv2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
-              - name: lv3
-                size: "{{ volume3_size }}"
-                mount_point: "{{ mount_location3 }}"
-
-    - name: Verify role results - 3
-      include_tasks: verify-role-results.yml
-
-    - name: Create a RAID1 lvm raid device
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-                raid_level: raid1
-
-    - name: Verify role results - 4
-      include_tasks: verify-role-results.yml
-
-    - name: Repeat the previous invocation to verify idempotence - 2
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_level: raid1
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-
-    - name: Verify role results - 5
-      include_tasks: verify-role-results.yml
-
-    - name: Remove the device created above - 2
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: absent
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_level: raid1
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-
-    - name: Verify role results - 6
-      include_tasks: verify-role-results.yml
-
-    - name: Create a RAID0 lvm raid device
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-                raid_level: raid0
-
-    - name: Verify role results - 7
-      include_tasks: verify-role-results.yml
-
-    - name: Repeat the previous invocation to verify idempotence - 3
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_level: raid0
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-
-    - name: Verify role results - 8
-      include_tasks: verify-role-results.yml
-
-    - name: Remove the device created above - 3
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: absent
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_level: raid0
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-
-    - name: Verify role results - 9
-      include_tasks: verify-role-results.yml
-
-    - name: Create a RAID1 lvm raid device on encrypted VG
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: present
-            encryption: true
-            encryption_password: yabbadabbadoo
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-                raid_level: raid0
-
-    - name: Verify role results - 10
-      include_tasks: verify-role-results.yml
-
-    - name: Remove the device created above - 4
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: absent
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-                raid_level: raid0
-                raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
-
-    - name: Verify role results - 11
-      include_tasks: verify-role-results.yml
-
-    - name: Create encrypted RAID1 LVM device
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            type: lvm
-            disks: "{{ unused_disks }}"
-            raid_level: raid1
-            encryption: true
-            encryption_password: yabbadabbadoo
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-
-    - name: Verify role results - 12
-      include_tasks: verify-role-results.yml
-
-    - name: Remove the device created above - 5
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            type: lvm
-            state: absent
-            disks: "{{ unused_disks }}"
-            raid_level: raid1
-            encryption: true
-            encryption_password: yabbadabbadoo
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-
-    - name: Verify role results - 13
-      include_tasks: verify-role-results.yml
-
-    - name: Run test on supported platforms
-      when: ((is_fedora and blivet_pkg_version is version("3.7.1-2", ">=")) or
-             (is_rhel8 and blivet_pkg_version is version("3.6.0-5", ">=")) or
-             (is_rhel9 and blivet_pkg_version is version("3.6.0-6", ">=")) or
-             is_rhel10)
+    - name: Run tests
       block:
-        - name: Create a RAID0 lvm raid device with custom stripe size
+        - name: Storage test setup
+          ansible.builtin.include_tasks: tasks/setup.yml
+          vars:
+            __storage_get_package_facts: true
+
+        - name: Create a RAID0 device
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: "raid0"
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                  - name: lv2
+                    size: "{{ volume2_size }}"
+                    mount_point: "{{ mount_location2 }}"
+                  - name: lv3
+                    size: "{{ volume3_size }}"
+                    mount_point: "{{ mount_location3 }}"
+
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
+
+        - name: Repeat the previous invocation to verify idempotence
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: "raid0"
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                  - name: lv2
+                    size: "{{ volume2_size }}"
+                    mount_point: "{{ mount_location2 }}"
+                  - name: lv3
+                    size: "{{ volume3_size }}"
+                    mount_point: "{{ mount_location3 }}"
+
+        - name: Verify role results - 2
+          include_tasks: verify-role-results.yml
+
+        - name: Remove the device created above
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: raid0
+                state: absent
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                  - name: lv2
+                    size: "{{ volume2_size }}"
+                    mount_point: "{{ mount_location2 }}"
+                  - name: lv3
+                    size: "{{ volume3_size }}"
+                    mount_point: "{{ mount_location3 }}"
+
+        - name: Verify role results - 3
+          include_tasks: verify-role-results.yml
+
+        - name: Create a RAID1 lvm raid device
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                    raid_level: raid1
+
+        - name: Verify role results - 4
+          include_tasks: verify-role-results.yml
+
+        - name: Repeat the previous invocation to verify idempotence - 2
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_level: raid1
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+        - name: Verify role results - 5
+          include_tasks: verify-role-results.yml
+
+        - name: Remove the device created above - 2
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: absent
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_level: raid1
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+        - name: Verify role results - 6
+          include_tasks: verify-role-results.yml
+
+        - name: Create a RAID0 lvm raid device
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
@@ -292,12 +161,29 @@
                     mount_point: "{{ mount_location1 }}"
                     raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
                     raid_level: raid0
-                    raid_stripe_size: "256 KiB"
 
-        - name: Verify role results - 14
+        - name: Verify role results - 7
           include_tasks: verify-role-results.yml
 
-        - name: Remove the device created above - 6
+        - name: Repeat the previous invocation to verify idempotence - 3
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_level: raid0
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+        - name: Verify role results - 8
+          include_tasks: verify-role-results.yml
+
+        - name: Remove the device created above - 3
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             storage_pools:
@@ -312,5 +198,128 @@
                     raid_level: raid0
                     raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
 
-        - name: Verify role results - 15
+        - name: Verify role results - 9
           include_tasks: verify-role-results.yml
+
+        - name: Create a RAID0 lvm raid device on encrypted VG
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: present
+                encryption: true
+                encryption_password: yabbadabbadoo
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                    raid_level: raid0
+
+        - name: Verify role results - 10
+          include_tasks: verify-role-results.yml
+
+        - name: Remove the device created above - 4
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: absent
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                    raid_level: raid0
+                    raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+        - name: Verify role results - 11
+          include_tasks: verify-role-results.yml
+
+        - name: Create encrypted RAID1 LVM device
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                type: lvm
+                disks: "{{ unused_disks }}"
+                raid_level: raid1
+                encryption: true
+                encryption_password: yabbadabbadoo
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+
+        - name: Verify role results - 12
+          include_tasks: verify-role-results.yml
+
+        - name: Remove the device created above - 5
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                type: lvm
+                state: absent
+                disks: "{{ unused_disks }}"
+                raid_level: raid1
+                encryption: true
+                encryption_password: yabbadabbadoo
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+
+        - name: Verify role results - 13
+          include_tasks: verify-role-results.yml
+
+        - name: Run test on supported platforms
+          when: ((is_fedora and blivet_pkg_version is version("3.7.1-2", ">=")) or
+                (is_rhel8 and blivet_pkg_version is version("3.6.0-5", ">=")) or
+                (is_rhel9 and blivet_pkg_version is version("3.6.0-6", ">=")) or
+                is_rhel10)
+          block:
+            - name: Create a RAID0 lvm raid device with custom stripe size
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                storage_pools:
+                  - name: vg1
+                    disks: "{{ unused_disks }}"
+                    type: lvm
+                    state: present
+                    volumes:
+                      - name: lv1
+                        size: "{{ volume1_size }}"
+                        mount_point: "{{ mount_location1 }}"
+                        raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+                        raid_level: raid0
+                        raid_stripe_size: "256 KiB"
+
+            - name: Verify role results - 14
+              include_tasks: verify-role-results.yml
+
+            - name: Remove the device created above - 6
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                storage_pools:
+                  - name: vg1
+                    disks: "{{ unused_disks }}"
+                    type: lvm
+                    state: absent
+                    volumes:
+                      - name: lv1
+                        size: "{{ volume1_size }}"
+                        mount_point: "{{ mount_location1 }}"
+                        raid_level: raid0
+                        raid_disks: "{{ [unused_disks[0], unused_disks[1]] }}"
+
+            - name: Verify role results - 15
+              include_tasks: verify-role-results.yml
+
+      rescue:
+        - name: Gather information for debugging failure
+          include_tasks: tasks/debug.yml
+
+        - name: Fail the test
+          fail:

--- a/tests/tests_create_raid_volume_then_remove.yml
+++ b/tests/tests_create_raid_volume_then_remove.yml
@@ -10,45 +10,54 @@
     __storage_disks_needed: 2
 
   tasks:
-    - name: Prep storage role and discover unused disks
-      ansible.builtin.include_tasks: tasks/setup.yml
+    - name: Run tests
+      block:
+        - name: Prep storage role and discover unused disks
+          ansible.builtin.include_tasks: tasks/setup.yml
 
-    - name: Create a RAID0 device mounted on {{ mount_location }}
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test1
-            type: raid
-            raid_level: raid0
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
+        - name: Create a RAID0 device mounted on {{ mount_location }}
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test1
+                type: raid
+                raid_level: raid0
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Repeat the previous invocation to verify idempotence
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test1
-            type: raid
-            raid_level: raid0
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
+        - name: Repeat the previous invocation to verify idempotence
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test1
+                type: raid
+                raid_level: raid0
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
 
-    - name: Verify role results - 2
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 2
+          include_tasks: verify-role-results.yml
 
-    - name: Remove the disk device created above
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test1
-            type: raid
-            raid_level: raid0
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
-            state: absent
+        - name: Remove the disk device created above
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test1
+                type: raid
+                raid_level: raid0
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                state: absent
 
-    - name: Verify role results - 3
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 3
+          include_tasks: verify-role-results.yml
+
+      rescue:
+        - name: Gather information for debugging failure
+          include_tasks: tasks/debug.yml
+
+        - name: Fail the test
+          fail:

--- a/tests/tests_raid_pool_options.yml
+++ b/tests/tests_raid_pool_options.yml
@@ -17,120 +17,129 @@
     - tests::lvm
 
   tasks:
-    - name: Prep storage role and discover unused disks
-      ansible.builtin.include_tasks: tasks/setup.yml
+    - name: Run tests
+      block:
+        - name: Prep storage role and discover unused disks
+          ansible.builtin.include_tasks: tasks/setup.yml
 
-    - name: Create a RAID1 device
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: "raid1"
-            raid_device_count: 2
-            raid_spare_count: 1
-            raid_metadata_version: "1.0"
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: Lv2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
-              - name: Lv3
-                size: "{{ volume3_size }}"
-                mount_point: "{{ mount_location3 }}"
+        - name: Create a RAID1 device
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: "raid1"
+                raid_device_count: 2
+                raid_spare_count: 1
+                raid_metadata_version: "1.0"
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                  - name: Lv2
+                    size: "{{ volume2_size }}"
+                    mount_point: "{{ mount_location2 }}"
+                  - name: Lv3
+                    size: "{{ volume3_size }}"
+                    mount_point: "{{ mount_location3 }}"
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Repeat the previous invocation minus the pool raid options
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            state: present
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: Lv2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
-              - name: Lv3
-                size: "{{ volume3_size }}"
-                mount_point: "{{ mount_location3 }}"
+        - name: Repeat the previous invocation minus the pool raid options
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                state: present
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                  - name: Lv2
+                    size: "{{ volume2_size }}"
+                    mount_point: "{{ mount_location2 }}"
+                  - name: Lv3
+                    size: "{{ volume3_size }}"
+                    mount_point: "{{ mount_location3 }}"
 
-    - name: Assert to preserve RAID settings for preexisting pool
-      assert:
-        that: not blivet_output.changed and
-              blivet_output.pools[0].raid_level == 'raid1' and
-              blivet_output.pools[0].raid_device_count == 2 and
-              blivet_output.pools[0].raid_spare_count == 1 and
-              blivet_output.pools[0].raid_metadata_version == '1.0'
-        msg: "Failure to preserve RAID settings for preexisting pool."
+        - name: Assert to preserve RAID settings for preexisting pool
+          assert:
+            that: not blivet_output.changed and
+                  blivet_output.pools[0].raid_level == 'raid1' and
+                  blivet_output.pools[0].raid_device_count == 2 and
+                  blivet_output.pools[0].raid_spare_count == 1 and
+                  blivet_output.pools[0].raid_metadata_version == '1.0'
+            msg: "Failure to preserve RAID settings for preexisting pool."
 
-    - name: Verify role results - 2
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 2
+          include_tasks: verify-role-results.yml
 
-    - name: Remove the pool created above
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: "raid1"
-            raid_device_count: 2
-            raid_spare_count: 1
-            raid_metadata_version: "1.0"
-            state: absent
-            volumes:
-              - name: lv1
-                size: "{{ volume1_size }}"
-                mount_point: "{{ mount_location1 }}"
-              - name: Lv2
-                size: "{{ volume2_size }}"
-                mount_point: "{{ mount_location2 }}"
-              - name: Lv3
-                size: "{{ volume3_size }}"
-                mount_point: "{{ mount_location3 }}"
+        - name: Remove the pool created above
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: "raid1"
+                raid_device_count: 2
+                raid_spare_count: 1
+                raid_metadata_version: "1.0"
+                state: absent
+                volumes:
+                  - name: lv1
+                    size: "{{ volume1_size }}"
+                    mount_point: "{{ mount_location1 }}"
+                  - name: Lv2
+                    size: "{{ volume2_size }}"
+                    mount_point: "{{ mount_location2 }}"
+                  - name: Lv3
+                    size: "{{ volume3_size }}"
+                    mount_point: "{{ mount_location3 }}"
 
-    - name: Verify role results - 3
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 3
+          include_tasks: verify-role-results.yml
 
-    - name: Create a RAID0 device
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: "raid0"
-            raid_device_count: 3
-            raid_metadata_version: "1.0"
-            raid_chunk_size: "1024 KiB"
-            state: present
+        - name: Create a RAID0 device
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: "raid0"
+                raid_device_count: 3
+                raid_metadata_version: "1.0"
+                raid_chunk_size: "1024 KiB"
+                state: present
 
-    - name: Verify role results - 4
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 4
+          include_tasks: verify-role-results.yml
 
-    - name: Remove the pool created above - 2
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_pools:
-          - name: vg1
-            disks: "{{ unused_disks }}"
-            type: lvm
-            raid_level: "raid0"
-            raid_device_count: 3
-            raid_metadata_version: "1.0"
-            raid_chunk_size: "1024 KiB"
-            state: absent
+        - name: Remove the pool created above - 2
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_pools:
+              - name: vg1
+                disks: "{{ unused_disks }}"
+                type: lvm
+                raid_level: "raid0"
+                raid_device_count: 3
+                raid_metadata_version: "1.0"
+                raid_chunk_size: "1024 KiB"
+                state: absent
 
-    - name: Verify role results - 5
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 5
+          include_tasks: verify-role-results.yml
+
+      rescue:
+        - name: Gather information for debugging failure
+          include_tasks: tasks/debug.yml
+
+        - name: Fail the test
+          fail:

--- a/tests/tests_raid_volume_options.yml
+++ b/tests/tests_raid_volume_options.yml
@@ -10,95 +10,104 @@
     __storage_disks_needed: 3
 
   tasks:
-    - name: Prep storage role and discover unused disks
-      ansible.builtin.include_tasks: tasks/setup.yml
+    - name: Run tests
+      block:
+        - name: Prep storage role and discover unused disks
+          ansible.builtin.include_tasks: tasks/setup.yml
 
-    - name: Create a RAID0 device mounted on "{{ mount_location }}"
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test1
-            type: raid
-            raid_level: "raid1"
-            raid_device_count: 2
-            raid_spare_count: 1
-            raid_metadata_version: "1.0"
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
-            state: present
+        - name: Create a RAID1 device mounted on "{{ mount_location }}"
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test1
+                type: raid
+                raid_level: "raid1"
+                raid_device_count: 2
+                raid_spare_count: 1
+                raid_metadata_version: "1.0"
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                state: present
 
-    - name: Verify role results
-      include_tasks: verify-role-results.yml
+        - name: Verify role results
+          include_tasks: verify-role-results.yml
 
-    - name: Re-run the same invocation without the RAID params
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test1
-            type: raid
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
-            state: present
+        - name: Re-run the same invocation without the RAID params
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test1
+                type: raid
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                state: present
 
-    - name: Assert to preserve RAID settings for preexisting volume
-      assert:
-        that: not blivet_output.changed and
-              blivet_output.volumes[0].raid_level == 'raid1' and
-              blivet_output.volumes[0].raid_device_count == 2 and
-              blivet_output.volumes[0].raid_spare_count == 1 and
-              blivet_output.volumes[0].raid_metadata_version == '1.0'
-        msg: "Failure to preserve RAID settings for preexisting volume."
+        - name: Assert to preserve RAID settings for preexisting volume
+          assert:
+            that: not blivet_output.changed and
+                  blivet_output.volumes[0].raid_level == 'raid1' and
+                  blivet_output.volumes[0].raid_device_count == 2 and
+                  blivet_output.volumes[0].raid_spare_count == 1 and
+                  blivet_output.volumes[0].raid_metadata_version == '1.0'
+            msg: "Failure to preserve RAID settings for preexisting volume."
 
-    - name: Verify role results - 2
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 2
+          include_tasks: verify-role-results.yml
 
-    - name: Remove the disk device created above
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test1
-            type: raid
-            raid_level: "raid1"
-            raid_device_count: 2
-            raid_spare_count: 1
-            raid_metadata_version: "1.0"
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
-            state: absent
+        - name: Remove the disk device created above
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test1
+                type: raid
+                raid_level: "raid1"
+                raid_device_count: 2
+                raid_spare_count: 1
+                raid_metadata_version: "1.0"
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                state: absent
 
-    - name: Verify role results - 3
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 3
+          include_tasks: verify-role-results.yml
 
-    - name: Create again a RAID0 device mounted on "{{ mount_location }}"
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test0
-            type: raid
-            raid_level: "raid0"
-            raid_device_count: 3
-            raid_metadata_version: "1.0"
-            raid_chunk_size: "1024K"
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
-            state: present
+        - name: Create again a RAID0 device mounted on "{{ mount_location }}"
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test0
+                type: raid
+                raid_level: "raid0"
+                raid_device_count: 3
+                raid_metadata_version: "1.0"
+                raid_chunk_size: "1024K"
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                state: present
 
-    - name: Verify role results - 4
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 4
+          include_tasks: verify-role-results.yml
 
-    - name: Remove the disk device created above - 2
-      include_tasks: tasks/run_role_with_clear_facts.yml
-      vars:
-        storage_volumes:
-          - name: test0
-            type: raid
-            raid_level: "raid0"
-            raid_device_count: 3
-            raid_metadata_version: "1.0"
-            raid_chunk_size: "1024K"
-            disks: "{{ unused_disks }}"
-            mount_point: "{{ mount_location }}"
-            state: absent
+        - name: Remove the disk device created above - 2
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            storage_volumes:
+              - name: test0
+                type: raid
+                raid_level: "raid0"
+                raid_device_count: 3
+                raid_metadata_version: "1.0"
+                raid_chunk_size: "1024K"
+                disks: "{{ unused_disks }}"
+                mount_point: "{{ mount_location }}"
+                state: absent
 
-    - name: Verify role results - 5
-      include_tasks: verify-role-results.yml
+        - name: Verify role results - 5
+          include_tasks: verify-role-results.yml
+
+      rescue:
+        - name: Gather information for debugging failure
+          include_tasks: tasks/debug.yml
+
+        - name: Fail the test
+          fail:


### PR DESCRIPTION
The raid tests are the ones which most often fail with flakes.  Add
some debugging to try to find out why they fail.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a debug task to capture detailed system/storage/RAID diagnostics when tests fail, ensuring required tools are present.
  * Wrapped RAID test sequences in structured blocks with rescue handling so failures trigger debug capture and then fail explicitly.
  * Reorganized RAID lifecycle and option tests (create/verify/idempotence/remove) for clearer ordering and more reliable, diagnosable outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->