### PR TITLE
docs: move ostree stratis to README.me ostree section [citest_skip]

### DIFF
--- a/README-ostree.md
+++ b/README-ostree.md
@@ -6,10 +6,6 @@ role cannot install packages. Instead, it will just verify that the necessary
 packages and any other `/usr` files are pre-installed. The role will change the
 package manager to one that is compatible with `rpm-ostree` systems.
 
-If you are not managing stratis pools or volumes, remove `stratisd` and
-`stratis-cli` from the ostree image package list generated from
-`.ostree/get_ostree_data.sh`.
-
 ## Building
 
 To build an ostree image for a particular operating system distribution and

--- a/README.md
+++ b/README.md
@@ -428,7 +428,14 @@ platforms with "buggy" udev.
 
 ## rpm-ostree
 
-See README-ostree.md
+If you are not managing stratis pools or volumes, remove `stratisd` and
+`stratis-cli` from the ostree image package list generated from
+`.ostree/get_ostree_data.sh`.
+
+If you do not want to use VDO, remove the vdo related packages from
+the ostree image package list.
+
+For more information, see README-ostree.md
 
 ## License
 


### PR DESCRIPTION
README-ostree.md is provided by .github automation, so move
the stratis information to the ostree section of README.md.
Also add a similar note for vdo.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
