### PR TITLE
fix: Select mount module by managed node python version

### DIFF
--- a/library/mount_ansible_29.py
+++ b/library/mount_ansible_29.py
@@ -1,0 +1,1050 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Red Hat, inc
+# Written by Seth Vidal
+# based on the mount modules from salt and puppet
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# This is a vendored copy of ansible.posix.mount, used only on ansible 2.9
+# (ansible-engine), where ansible.posix cannot be installed. It carries no
+# dependency on the collection (the ismount() helper, normally imported from
+# the collection's module_utils, is inlined below) so it can ship inside the
+# role's library/ directory. Newer ansible uses the latest ansible.posix.mount
+# via the bare "mount" name instead. Keep in sync with upstream when needed.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: mount_ansible_29
+short_description: Control active and configured mount points
+description:
+  - This module controls active and configured mount points in C(/etc/fstab).
+author:
+  - Ansible Core Team
+  - Seth Vidal (@skvidal)
+options:
+  path:
+    description:
+      - Path to the mount point (e.g. C(/mnt/files)).
+      - Before Ansible 2.3 this option was only usable as O(ignore:dest), O(ignore:destfile), and O(name).
+    type: path
+    required: true
+    aliases: [ name ]
+  src:
+    description:
+      - Device (or NFS volume, or something else) to be mounted on I(path).
+      - Required when O(state) set to V(present), V(mounted), or V(ephemeral).
+      - Ignored when O(state) set to V(absent) or V(unmounted).
+    type: path
+  fstype:
+    description:
+      - Filesystem type.
+      - Required when O(state) is V(present), V(mounted), or V(ephemeral).
+    type: str
+  opts:
+    description:
+      - Mount options (see fstab(5), or vfstab(4) on Solaris).
+    type: str
+  opts_no_log:
+    description:
+      - Do not log opts.
+    type: bool
+    default: false
+  dump:
+    description:
+      - Dump (see fstab(5)).
+      - Note that if set to C(null) and O(state=present),
+        it will cease to work and duplicate entries will be made
+        with subsequent runs.
+      - Has no effect on Solaris systems or when used with O(state=ephemeral).
+    type: str
+    default: '0'
+  passno:
+    description:
+      - Passno (see fstab(5)).
+      - Note that if set to C(null) and O(state=present),
+        it will cease to work and duplicate entries will be made
+        with subsequent runs.
+      - Deprecated on Solaris systems. Has no effect when used with O(state=ephemeral).
+    type: str
+    default: '0'
+  state:
+    description:
+      - If V(mounted), the device will be actively mounted and appropriately
+        configured in I(fstab). If the mount point is not present, the mount
+        point will be created.
+      - If V(unmounted), the device will be unmounted without changing I(fstab).
+      - V(present) only specifies that the device is to be configured in
+        I(fstab) and does not trigger or require a mount.
+      - V(ephemeral) only specifies that the device is to be mounted, without changing
+        I(fstab). If it is already mounted, a remount will be triggered.
+        This will always return RV(ignore:changed=true). If the mount point O(path)
+        has already a device mounted on, and its source is different than O(src),
+        the module will fail to avoid unexpected unmount or mount point override.
+        If the mount point is not present, the mount point will be created.
+        The I(fstab) is completely ignored. This option is added in version 1.5.0.
+      - V(absent) specifies that the mount point entry O(path) will be removed
+        from I(fstab) and will also unmount the mounted device and remove the
+        mount point. A mounted device will be unmounted regardless of O(src) or its
+        real source. V(absent) does not unmount recursively, and the module will
+        fail if multiple devices are mounted on the same mount point. Using
+        V(absent) with a mount point that is not registered in the I(fstab) has
+        no effect, use V(unmounted) instead.
+      - V(remounted) specifies that the device will be remounted for when you
+        want to force a refresh on the mount itself (added in 2.9). This will
+        always return RV(ignore:changed=true). If O(opts) is set, the options will be
+        applied to the remount, but will not change I(fstab).  Additionally,
+        if O(opts) is set, and the remount command fails, the module will
+        error to prevent unexpected mount changes.  Try using V(mounted)
+        instead to work around this issue.  V(remounted) expects the mount point
+        to be present in the I(fstab). To remount a mount point not registered
+        in I(fstab), use V(ephemeral) instead, especially with BSD nodes.
+      - V(absent_from_fstab) specifies that the device mount's entry will be
+        removed from I(fstab). This option does not unmount it or delete the
+        mountpoint.
+    type: str
+    required: true
+    choices: [ absent, absent_from_fstab, mounted, present, unmounted, remounted, ephemeral ]
+  fstab:
+    description:
+      - File to use instead of C(/etc/fstab).
+      - You should not use this option unless you really know what you are doing.
+      - This might be useful if you need to configure mountpoints in a chroot environment.
+      - OpenBSD does not allow specifying alternate fstab files with mount so do not
+        use this on OpenBSD with any state that operates on the live filesystem.
+      - This parameter defaults to C(/etc/fstab) or C(/etc/vfstab) on Solaris.
+      - This parameter is ignored when O(state=ephemeral).
+    type: str
+  boot:
+    description:
+      - Determines if the filesystem should be mounted on boot.
+      - Only applies to Solaris and Linux systems.
+      - For Solaris systems, C(true) will set C(yes) as the value of mount at boot
+        in C(/etc/vfstab).
+      - For Linux, FreeBSD, NetBSD and OpenBSD systems, C(false) will add C(noauto)
+        to mount options in C(/etc/fstab).
+      - To avoid mount option conflicts, if C(noauto) specified in O(opts),
+        mount module will ignore O(boot).
+      - This parameter is ignored when O(state=ephemeral).
+    type: bool
+    default: true
+  backup:
+    description:
+      - Create a backup file including the timestamp information so you can get
+        the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: false
+notes:
+  - As of Ansible 2.3, the O(name) option has been changed to O(path) as
+    default, but O(name) still works as well.
+  - Using O(state=remounted) with O(opts) set may create unexpected results based on
+    the existing options already defined on mount, so care should be taken to
+    ensure that conflicting options are not present before hand.
+'''
+
+EXAMPLES = r'''
+# Before 2.3, option 'name' was used instead of 'path'
+- name: Mount DVD read-only
+  mount_ansible_29:
+    path: /mnt/dvd
+    src: /dev/sr0
+    fstype: iso9660
+    opts: ro,noauto
+    state: present
+
+- name: Mount up device by label
+  mount_ansible_29:
+    path: /srv/disk
+    src: LABEL=SOME_LABEL
+    fstype: ext4
+    state: present
+
+- name: Mount up device by UUID
+  mount_ansible_29:
+    path: /home
+    src: UUID=b3e48f45-f933-4c8e-a700-22a159ec9077
+    fstype: xfs
+    opts: noatime
+    state: present
+
+- name: Unmount a mounted volume
+  mount_ansible_29:
+    path: /tmp/mnt-pnt
+    state: unmounted
+
+- name: Remount a mounted volume
+  mount_ansible_29:
+    path: /tmp/mnt-pnt
+    state: remounted
+
+# The following will not save changes to fstab, and only be temporary until
+# a reboot, or until calling "state: unmounted" followed by "state: mounted"
+# on the same "path"
+- name: Remount a mounted volume and append exec to the existing options
+  mount_ansible_29:
+    path: /tmp
+    state: remounted
+    opts: exec
+
+- name: Mount and bind a volume
+  mount_ansible_29:
+    path: /system/new_volume/boot
+    src: /boot
+    opts: bind
+    state: mounted
+    fstype: none
+
+- name: Mount an NFS volume
+  mount_ansible_29:
+    src: 192.168.1.100:/nfs/ssd/shared_data
+    path: /mnt/shared_data
+    opts: rw,sync,hard
+    state: mounted
+    fstype: nfs
+'''
+
+import errno
+import os
+import platform
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.parsing.convert_bool import boolean
+
+
+# Inlined from ansible_collections.ansible.posix.plugins.module_utils.mount so
+# this vendored module has no dependency on the collection. This particular
+# snippet is based on Lib/posixpath.py of cpython and is licensed under the
+# PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
+def ismount(path):
+    """Test whether a path is a mount point
+    This is a copy of the upstream version of ismount(). Originally this was copied here as a workaround
+    until Python issue 2466 was fixed. Now it is here so this will work on older versions of Python
+    that may not have the upstream fix.
+    https://github.com/ansible/ansible-modules-core/issues/2186
+    http://bugs.python.org/issue2466
+    """
+    try:
+        s1 = os.lstat(path)
+    except (OSError, ValueError):
+        # It doesn't exist -- so not a mount point. :-)
+        return False
+    else:
+        # A symlink can never be a mount point
+        if os.path.stat.S_ISLNK(s1.st_mode):
+            return False
+
+    if isinstance(path, bytes):
+        parent = os.path.join(path, b'..')
+    else:
+        parent = os.path.join(path, '..')
+    parent = os.path.realpath(parent)
+    try:
+        s2 = os.lstat(parent)
+    except (OSError, ValueError):
+        return False
+
+    dev1 = s1.st_dev
+    dev2 = s2.st_dev
+    if dev1 != dev2:
+        return True     # path/.. on a different device as path
+    ino1 = s1.st_ino
+    ino2 = s2.st_ino
+    if ino1 == ino2:
+        return True     # path/.. is the same i-node as path
+    return False
+
+
+def write_fstab(module, lines, path):
+
+    if module.params['backup']:
+        backup_file = module.backup_local(path)
+    else:
+        backup_file = ""
+
+    fs_w = open(path, 'w')
+
+    for l in lines:
+        fs_w.write(l)
+
+    fs_w.flush()
+    fs_w.close()
+
+    return backup_file
+
+
+def _escape_fstab(v):
+    """Escape invalid characters in fstab fields.
+
+    space (040)
+    ampersand (046)
+    backslash (134)
+    """
+
+    if isinstance(v, int):
+        return v
+    else:
+        return (
+            v.
+            replace('\\', '\\134').
+            replace(' ', '\\040').
+            replace('&', '\\046'))
+
+
+def set_mount(module, args):
+    """Set/change a mount point location in fstab."""
+    name, backup_lines, changed = _set_mount_save_old(module, args)
+    return name, changed
+
+
+def _set_mount_save_old(module, args):
+    """Set/change a mount point location in fstab. Save the old fstab contents."""
+
+    to_write = []
+    old_lines = []
+    exists = False
+    changed = False
+    escaped_args = dict([(k, _escape_fstab(v)) for k, v in iteritems(args) if k != 'warnings'])
+    new_line = '%(src)s %(name)s %(fstype)s %(opts)s %(dump)s %(passno)s\n'
+
+    if platform.system() == 'SunOS':
+        new_line = (
+            '%(src)s - %(name)s %(fstype)s %(passno)s %(boot)s %(opts)s\n')
+
+    for line in open(args['fstab'], 'r').readlines():
+        # Append newline if the line in fstab does not finished with newline.
+        if not line.endswith('\n'):
+            line += '\n'
+
+        old_lines.append(line)
+
+        if not line.strip():
+            to_write.append(line)
+
+            continue
+
+        if line.strip().startswith('#'):
+            to_write.append(line)
+
+            continue
+
+        fields = line.split('#')[0].split()
+
+        # Check if we got a valid line for splitting
+        # (on Linux the 5th and the 6th field is optional)
+        if (
+                platform.system() == 'SunOS' and len(fields) != 7 or
+                platform.system() == 'Linux' and len(fields) not in [4, 5, 6] or
+                platform.system() not in ['SunOS', 'Linux'] and len(fields) != 6):
+            to_write.append(line)
+
+            continue
+
+        ld = {}
+
+        if platform.system() == 'SunOS':
+            (
+                ld['src'],
+                dash,
+                ld['name'],
+                ld['fstype'],
+                ld['passno'],
+                ld['boot'],
+                ld['opts']
+            ) = fields
+        else:
+            fields_labels = ['src', 'name', 'fstype', 'opts', 'dump', 'passno']
+
+            # The last two fields are optional on Linux so we fill in default values
+            ld['dump'] = 0
+            ld['passno'] = 0
+
+            # Fill in the rest of the available fields
+            for i, field in enumerate(fields):
+                ld[fields_labels[i]] = field
+
+        # Check if we found the correct line
+        if (
+                ld['name'] != escaped_args['name'] or (
+                    # In the case of swap, check the src instead
+                    'src' in args and
+                    ld['name'] == 'none' and
+                    ld['fstype'] == 'swap' and
+                    ld['src'] != args['src'])):
+            to_write.append(line)
+
+            continue
+
+        # If we got here we found a match - let's check if there is any
+        # difference
+        exists = True
+        args_to_check = ('src', 'fstype', 'opts', 'dump', 'passno')
+
+        if platform.system() == 'SunOS':
+            args_to_check = ('src', 'fstype', 'passno', 'boot', 'opts')
+
+        for t in args_to_check:
+            if ld[t] != escaped_args[t]:
+                ld[t] = escaped_args[t]
+                changed = True
+
+        if changed:
+            to_write.append(new_line % ld)
+        else:
+            to_write.append(line)
+
+    if not exists:
+        to_write.append(new_line % escaped_args)
+        changed = True
+
+    if changed and not module.check_mode:
+        args['backup_file'] = write_fstab(module, to_write, args['fstab'])
+
+    return (args['name'], old_lines, changed)
+
+
+def unset_mount(module, args):
+    """Remove a mount point from fstab."""
+
+    to_write = []
+    changed = False
+    escaped_name = _escape_fstab(args['name'])
+
+    for line in open(args['fstab'], 'r').readlines():
+        if not line.strip():
+            to_write.append(line)
+
+            continue
+
+        if line.strip().startswith('#'):
+            to_write.append(line)
+
+            continue
+
+        # Check if we got a valid line for splitting
+        if (
+                platform.system() == 'SunOS' and len(line.split()) != 7 or
+                platform.system() != 'SunOS' and len(line.split()) != 6):
+            to_write.append(line)
+
+            continue
+
+        ld = {}
+
+        if platform.system() == 'SunOS':
+            (
+                ld['src'],
+                dash,
+                ld['name'],
+                ld['fstype'],
+                ld['passno'],
+                ld['boot'],
+                ld['opts']
+            ) = line.split()
+        else:
+            (
+                ld['src'],
+                ld['name'],
+                ld['fstype'],
+                ld['opts'],
+                ld['dump'],
+                ld['passno']
+            ) = line.split()
+
+        if (
+                ld['name'] != escaped_name or (
+                    # In the case of swap, check the src instead
+                    'src' in args and
+                    ld['name'] == 'none' and
+                    ld['fstype'] == 'swap' and
+                    ld['src'] != args['src'])):
+            to_write.append(line)
+
+            continue
+
+        # If we got here we found a match - continue and mark changed
+        changed = True
+
+    if changed and not module.check_mode:
+        write_fstab(module, to_write, args['fstab'])
+
+    return (args['name'], changed)
+
+
+def _set_fstab_args(fstab_file):
+    result = []
+
+    if (
+            fstab_file and
+            fstab_file != '/etc/fstab' and
+            platform.system().lower() != 'sunos'):
+        if platform.system().lower().endswith('bsd'):
+            result.append('-F')
+        else:
+            result.append('-T')
+
+        result.append(fstab_file)
+
+    return result
+
+
+def _set_ephemeral_args(args):
+    result = []
+    # Set fstype switch according to platform. SunOS/Solaris use -F
+    if platform.system().lower() == 'sunos':
+        result.append('-F')
+    else:
+        result.append('-t')
+    result.append(args['fstype'])
+
+    # Even if '-o remount' is already set, specifying multiple -o is valid
+    if args['opts'] != 'defaults':
+        result += ['-o', args['opts']]
+
+    result.append(args['src'])
+
+    return result
+
+
+def mount(module, args):
+    """Mount up a path or remount if needed."""
+
+    mount_bin = module.get_bin_path('mount', required=True)
+    name = args['name']
+    cmd = [mount_bin]
+
+    if platform.system().lower() == 'openbsd':
+        # Use module.params['fstab'] here as args['fstab'] has been set to the
+        # default value.
+        if module.params['fstab'] is not None:
+            module.fail_json(
+                msg=(
+                    'OpenBSD does not support alternate fstab files. Do not '
+                    'specify the fstab parameter for OpenBSD hosts'))
+    else:
+        if module.params['state'] != 'ephemeral':
+            cmd += _set_fstab_args(args['fstab'])
+
+    if module.params['state'] == 'ephemeral':
+        cmd += _set_ephemeral_args(args)
+
+    cmd += [name]
+
+    rc, out, err = module.run_command(cmd)
+
+    if rc == 0:
+        return 0, ''
+    else:
+        return rc, out + err
+
+
+def umount(module, path):
+    """Unmount a path."""
+
+    umount_bin = module.get_bin_path('umount', required=True)
+    cmd = [umount_bin, path]
+
+    rc, out, err = module.run_command(cmd)
+
+    if rc == 0:
+        return 0, ''
+    else:
+        return rc, out + err
+
+
+def remount(module, args):
+    """Try to use 'remount' first and fallback to (u)mount if unsupported."""
+    mount_bin = module.get_bin_path('mount', required=True)
+    cmd = [mount_bin]
+
+    # Multiplatform remount opts
+    if platform.system().lower().endswith('bsd'):
+        if module.params['state'] == 'remounted' and args['opts'] != 'defaults':
+            cmd += ['-u', '-o', args['opts']]
+        else:
+            cmd += ['-u']
+    else:
+        if module.params['state'] == 'remounted' and args['opts'] != 'defaults':
+            cmd += ['-o', 'remount,' + args['opts']]
+        else:
+            cmd += ['-o', 'remount']
+
+    if platform.system().lower() == 'openbsd':
+        # Use module.params['fstab'] here as args['fstab'] has been set to the
+        # default value.
+        if module.params['fstab'] is not None:
+            module.fail_json(
+                msg=(
+                    'OpenBSD does not support alternate fstab files. Do not '
+                    'specify the fstab parameter for OpenBSD hosts'))
+    else:
+        if module.params['state'] != 'ephemeral':
+            cmd += _set_fstab_args(args['fstab'])
+
+    if module.params['state'] == 'ephemeral':
+        cmd += _set_ephemeral_args(args)
+
+    cmd += [args['name']]
+    out = err = ''
+
+    try:
+        if module.params['state'] != 'ephemeral' and platform.system().lower().endswith('bsd'):
+            # Note: Forcing BSDs to do umount/mount due to BSD remount not
+            # working as expected (suspect bug in the BSD mount command)
+            # Interested contributor could rework this to use mount options on
+            # the CLI instead of relying on fstab
+            # https://github.com/ansible/ansible-modules-core/issues/5591
+            # Note: this does not affect ephemeral state as all options
+            # are set on the CLI and fstab is expected to be ignored.
+            rc = 1
+        else:
+            rc, out, err = module.run_command(cmd)
+    except Exception:
+        rc = 1
+
+    msg = ''
+
+    if rc != 0:
+        msg = out + err
+
+        if module.params['state'] == 'remounted' and args['opts'] != 'defaults':
+            module.fail_json(
+                msg=(
+                    'Options were specified with remounted, but the remount '
+                    'command failed. Failing in order to prevent an '
+                    'unexpected mount result. Try replacing this command with '
+                    'a "state: unmounted" followed by a "state: mounted" '
+                    'using the full desired mount options instead.'))
+
+        rc, msg = umount(module, args['name'])
+
+        if rc == 0:
+            rc, msg = mount(module, args)
+
+    return rc, msg
+
+
+# Note if we wanted to put this into module_utils we'd have to get permission
+# from @jupeter -- https://github.com/ansible/ansible-modules-core/pull/2923
+# @jtyr -- https://github.com/ansible/ansible-modules-core/issues/4439
+# and @abadger to relicense from GPLv3+
+def is_bind_mounted(module, linux_mounts, dest, src=None, fstype=None):
+    """Return whether the dest is bind mounted
+
+    :arg module: The AnsibleModule (used for helper functions)
+    :arg dest: The directory to be mounted under. This is the primary means
+        of identifying whether the destination is mounted.
+    :kwarg src: The source directory. If specified, this is used to help
+        ensure that we are detecting that the correct source is mounted there.
+    :kwarg fstype: The filesystem type. If specified this is also used to
+        help ensure that we are detecting the right mount.
+    :kwarg linux_mounts: Cached list of mounts for Linux.
+    :returns: True if the dest is mounted with src otherwise False.
+    """
+
+    is_mounted = False
+
+    if platform.system() == 'Linux' and linux_mounts is not None:
+        if src is None:
+            # That's for unmounted/absent
+            if dest in linux_mounts:
+                is_mounted = True
+        else:
+            if dest in linux_mounts:
+                is_mounted = linux_mounts[dest]['src'] == src
+
+    else:
+        bin_path = module.get_bin_path('mount', required=True)
+        cmd = '%s -l' % bin_path
+        rc, out, err = module.run_command(cmd)
+        mounts = []
+
+        if len(out):
+            mounts = to_native(out).strip().split('\n')
+
+        for mnt in mounts:
+            arguments = mnt.split()
+
+            if (
+                    (arguments[0] == src or src is None) and
+                    arguments[2] == dest and
+                    (arguments[4] == fstype or fstype is None)):
+                is_mounted = True
+
+            if is_mounted:
+                break
+
+    return is_mounted
+
+
+def get_linux_mounts(module, mntinfo_file="/proc/self/mountinfo"):
+    """Gather mount information"""
+
+    try:
+        f = open(mntinfo_file)
+    except IOError:
+        return
+
+    lines = map(str.strip, f.readlines())
+
+    try:
+        f.close()
+    except IOError:
+        module.fail_json(msg="Cannot close file %s" % mntinfo_file)
+
+    mntinfo = {}
+
+    for line in lines:
+        fields = line.split()
+
+        record = {
+            'id': int(fields[0]),
+            'parent_id': int(fields[1]),
+            'root': fields[3],
+            'dst': fields[4],
+            'opts': fields[5],
+            'fs': fields[-3],
+            'src': fields[-2]
+        }
+
+        mntinfo[record['id']] = record
+
+    mounts = {}
+
+    for mnt in mntinfo.values():
+        if mnt['parent_id'] != 1 and mnt['parent_id'] in mntinfo:
+            m = mntinfo[mnt['parent_id']]
+            if (
+                    len(m['root']) > 1 and
+                    mnt['root'].startswith("%s/" % m['root'])):
+                # Omit the parent's root in the child's root
+                # == Example:
+                # 140 136 253:2 /rootfs / rw - ext4 /dev/sdb2 rw
+                # 141 140 253:2 /rootfs/tmp/aaa /tmp/bbb rw - ext4 /dev/sdb2 rw
+                # == Expected result:
+                # src=/tmp/aaa
+                mnt['root'] = mnt['root'][len(m['root']):]
+
+            # Prepend the parent's dst to the child's root
+            # == Example:
+            # 42 60 0:35 / /tmp rw - tmpfs tmpfs rw
+            # 78 42 0:35 /aaa /tmp/bbb rw - tmpfs tmpfs rw
+            # == Expected result:
+            # src=/tmp/aaa
+            if m['dst'] != '/':
+                mnt['root'] = "%s%s" % (m['dst'], mnt['root'])
+            src = mnt['root']
+        else:
+            src = mnt['src']
+
+        record = {
+            'dst': mnt['dst'],
+            'src': src,
+            'opts': mnt['opts'],
+            'fs': mnt['fs']
+        }
+
+        mounts[mnt['dst']] = record
+
+    return mounts
+
+
+def _is_same_mount_src(module, src, mountpoint, linux_mounts):
+    """Return True if the mounted fs on mountpoint is the same source than src. Return False if mountpoint is not a mountpoint"""
+    # If the provided mountpoint is not a mountpoint, don't waste time
+    if (
+            not ismount(mountpoint) and
+            not is_bind_mounted(module, linux_mounts, mountpoint)):
+        return False
+
+    # Treat Linux bind mounts
+    if platform.system() == 'Linux' and linux_mounts is not None:
+        # For Linux bind mounts only: the mount command does not return
+        # the actual source for bind mounts, but the device of the source.
+        # is_bind_mounted() called with the 'src' parameter will return True if
+        # the mountpoint is a bind mount AND the source FS is the same than 'src'.
+        # is_bind_mounted() is not reliable on Solaris, NetBSD and OpenBSD.
+        # But we can rely on 'mount -v' on all other platforms, and Linux non-bind mounts.
+        if is_bind_mounted(module, linux_mounts, mountpoint, src):
+            return True
+
+    # mount with parameter -v has a close behavior on Linux, *BSD, SunOS
+    # Requires -v with SunOS. Without -v, source and destination are reversed
+    # Output format differs from a system to another, but field[0:3] are consistent: [src, 'on', dest]
+    cmd = '%s -v' % module.get_bin_path('mount', required=True)
+    rc, out, err = module.run_command(cmd)
+    mounts = []
+
+    if len(out):
+        mounts = to_native(out).strip().split('\n')
+    else:
+        module.fail_json(msg="Unable to retrieve mount info with command '%s'" % cmd)
+
+    for mnt in mounts:
+        fields = mnt.split()
+        mp_src = fields[0]
+        mp_dst = fields[2]
+        if mp_src == src and mp_dst == mountpoint:
+            return True
+
+    return False
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            boot=dict(type='bool', default=True),
+            dump=dict(type='str', default='0'),
+            fstab=dict(type='str'),
+            fstype=dict(type='str'),
+            path=dict(type='path', required=True, aliases=['name']),
+            opts=dict(type='str'),
+            opts_no_log=dict(type='bool', default=False),
+            passno=dict(type='str', no_log=False, default='0'),
+            src=dict(type='path'),
+            backup=dict(type='bool', default=False),
+            state=dict(type='str', required=True, choices=['absent', 'absent_from_fstab', 'mounted', 'present', 'unmounted', 'remounted', 'ephemeral']),
+        ),
+        supports_check_mode=True,
+        required_if=(
+            ['state', 'mounted', ['src', 'fstype']],
+            ['state', 'present', ['src', 'fstype']],
+            ['state', 'ephemeral', ['src', 'fstype']]
+        ),
+    )
+
+    if module.params['opts_no_log']:
+        module.no_log_values.add(module.params['opts'])
+
+    # solaris args:
+    #   name, src, fstype, opts, boot, passno, state, fstab=/etc/vfstab
+    # linux args:
+    #   name, src, fstype, opts, dump, passno, state, fstab=/etc/fstab
+    # Note: Do not modify module.params['fstab'] as we need to know if the user
+    # explicitly specified it in mount() and remount()
+    if platform.system().lower() == 'sunos':
+        args = dict(
+            name=module.params['path'],
+            opts='-',
+            passno='-',
+            fstab=module.params['fstab'],
+            boot='yes' if module.params['boot'] else 'no',
+            warnings=[]
+        )
+        if args['fstab'] is None:
+            args['fstab'] = '/etc/vfstab'
+    else:
+        args = dict(
+            name=module.params['path'],
+            opts='defaults',
+            dump='0',
+            passno='0',
+            fstab=module.params['fstab'],
+            boot='yes',
+            warnings=[]
+        )
+        if args['fstab'] is None:
+            args['fstab'] = '/etc/fstab'
+
+        # FreeBSD doesn't have any 'default' so set 'rw' instead
+        if platform.system() == 'FreeBSD':
+            args['opts'] = 'rw'
+
+    args['backup_file'] = ""
+    linux_mounts = []
+
+    # Cache all mounts here in order we have consistent results if we need to
+    # call is_bind_mounted() multiple times
+    if platform.system() == 'Linux':
+        linux_mounts = get_linux_mounts(module)
+
+        if linux_mounts is None:
+            args['warnings'].append('Cannot open file /proc/self/mountinfo.'
+                                    ' Bind mounts might be misinterpreted.')
+
+    # Override defaults with user specified params
+    for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab'):
+        if module.params[key] is not None:
+            args[key] = module.params[key]
+    if platform.system().lower() == 'linux' or platform.system().lower().endswith('bsd'):
+        # Linux, FreeBSD, NetBSD and OpenBSD have 'noauto' as mount option to
+        # handle mount on boot.  To avoid mount option conflicts, if 'noauto'
+        # specified in 'opts',  mount module will ignore 'boot'.
+        opts = args['opts'].split(',')
+        if module.params['boot'] and 'noauto' in opts:
+            args['warnings'].append("Ignore the 'boot' due to 'opts' contains 'noauto'.")
+        elif not module.params['boot']:
+            args['boot'] = 'no'
+            opts.append('noauto')
+            args['opts'] = ','.join(opts)
+
+    # If fstab file does not exist, we first need to create it. This mainly
+    # happens when fstab option is passed to the module.
+    # If state is 'ephemeral', we do not need fstab file
+    if module.params['state'] != 'ephemeral':
+        if not os.path.exists(args['fstab']):
+            if not os.path.exists(os.path.dirname(args['fstab'])):
+                os.makedirs(os.path.dirname(args['fstab']))
+            try:
+                open(args['fstab'], 'a').close()
+            except PermissionError as e:
+                module.fail_json(msg="Failed to open %s due to permission issue" % args['fstab'])
+            except Exception as e:
+                module.fail_json(msg="Failed to open %s due to %s" % (args['fstab'], to_native(e)))
+
+    # absent:
+    #   Remove from fstab and unmounted.
+    # unmounted:
+    #   Do not change fstab state, but unmount.
+    # present:
+    #   Add to fstab, do not change mount state.
+    # mounted:
+    #   Add to fstab if not there and make sure it is mounted. If it has
+    #   changed in fstab then remount it.
+    # ephemeral:
+    #   Do not change fstab state, but mount.
+
+    state = module.params['state']
+    name = module.params['path']
+    changed = False
+
+    if state == 'absent_from_fstab':
+        name, changed = unset_mount(module, args)
+    elif state == 'absent':
+        name, changed = unset_mount(module, args)
+
+        if changed and not module.check_mode:
+            if ismount(name) or is_bind_mounted(module, linux_mounts, name):
+                res, msg = umount(module, name)
+
+                if res:
+                    module.fail_json(
+                        msg="Error unmounting %s: %s" % (name, msg))
+
+            if os.path.exists(name):
+                try:
+                    os.rmdir(name)
+                except (OSError, IOError) as e:
+                    module.fail_json(msg="Error rmdir %s: %s" % (name, to_native(e)))
+    elif state == 'unmounted':
+        if ismount(name) or is_bind_mounted(module, linux_mounts, name):
+            if not module.check_mode:
+                res, msg = umount(module, name)
+
+                if res:
+                    module.fail_json(
+                        msg="Error unmounting %s: %s" % (name, msg))
+
+            changed = True
+    elif state == 'mounted' or state == 'ephemeral':
+        dirs_created = []
+        if not os.path.exists(name) and not module.check_mode:
+            try:
+                # Something like mkdir -p but with the possibility to undo.
+                # Based on some copy-paste from the "file" module.
+                curpath = ''
+                for dirname in name.strip('/').split('/'):
+                    curpath = '/'.join([curpath, dirname])
+                    # Remove leading slash if we're creating a relative path
+                    if not os.path.isabs(name):
+                        curpath = curpath.lstrip('/')
+
+                    b_curpath = to_bytes(curpath, errors='surrogate_or_strict')
+                    if not os.path.exists(b_curpath):
+                        try:
+                            os.mkdir(b_curpath)
+                            dirs_created.append(b_curpath)
+                        except OSError as ex:
+                            # Possibly something else created the dir since the os.path.exists
+                            # check above. As long as it's a dir, we don't need to error out.
+                            if not (ex.errno == errno.EEXIST and os.path.isdir(b_curpath)):
+                                raise
+
+            except (OSError, IOError) as e:
+                module.fail_json(
+                    msg="Error making dir %s: %s" % (name, to_native(e)))
+
+        # ephemeral: completely ignore fstab
+        if state != 'ephemeral':
+            name, backup_lines, changed = _set_mount_save_old(module, args)
+        else:
+            name, backup_lines, changed = args['name'], [], False
+        res = 0
+
+        if (
+                ismount(name) or
+                is_bind_mounted(
+                    module, linux_mounts, name, args['src'], args['fstype'])):
+            if changed and not module.check_mode:
+                res, msg = remount(module, args)
+                changed = True
+
+            # When 'state' == 'ephemeral', we don't know what is in fstab, and 'changed' is always False
+            if state == 'ephemeral':
+                # If state == 'ephemeral', check if the mountpoint src == module.params['src']
+                # If it doesn't, fail to prevent unwanted unmount or unwanted mountpoint override
+                if _is_same_mount_src(module, args['src'], args['name'], linux_mounts):
+                    changed = True
+                    if not module.check_mode:
+                        res, msg = remount(module, args)
+                else:
+                    module.fail_json(
+                        msg=(
+                            'Ephemeral mount point is already mounted with a different '
+                            'source than the specified one. Failing in order to prevent an '
+                            'unwanted unmount or override operation. Try replacing this command with '
+                            'a "state: unmounted" followed by a "state: ephemeral", or use '
+                            'a different destination path.'))
+
+        else:
+            # If not already mounted, mount it
+            changed = True
+
+            if not module.check_mode:
+                res, msg = mount(module, args)
+
+        if res:
+            # Not restoring fstab after a failed mount was reported as a bug,
+            # ansible/ansible#59183
+            # A non-working fstab entry may break the system at the reboot,
+            # so undo all the changes if possible.
+            try:
+                if state != 'ephemeral':
+                    write_fstab(module, backup_lines, args['fstab'])
+            except Exception:
+                pass
+
+            try:
+                for dirname in dirs_created[::-1]:
+                    os.rmdir(dirname)
+            except Exception:
+                pass
+
+            module.fail_json(msg="Error mounting %s: %s" % (name, msg))
+    elif state == 'present':
+        name, changed = set_mount(module, args)
+    elif state == 'remounted':
+        if not module.check_mode:
+            res, msg = remount(module, args)
+
+            if res:
+                module.fail_json(msg="Error remounting %s: %s" % (name, msg))
+
+        changed = True
+    else:
+        module.fail_json(msg='Unexpected position reached')
+
+    # If the managed node is Solaris, convert the boot value type to Boolean
+    #  to match the type of return value with the module argument.
+    if platform.system().lower() == 'sunos':
+        args['boot'] = boolean(args['boot'])
+    module.exit_json(changed=changed, **args)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/mount_ansible_29.py
+++ b/library/mount_ansible_29.py
@@ -212,7 +212,6 @@ import os
 import platform
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 
@@ -309,7 +308,7 @@ def _set_mount_save_old(module, args):
     old_lines = []
     exists = False
     changed = False
-    escaped_args = dict([(k, _escape_fstab(v)) for k, v in iteritems(args) if k != 'warnings'])
+    escaped_args = dict([(k, _escape_fstab(v)) for k, v in args.items() if k != 'warnings'])
     new_line = '%(src)s %(name)s %(fstype)s %(opts)s %(dump)s %(passno)s\n'
 
     if platform.system() == 'SunOS':

--- a/library/mount_python_27.py
+++ b/library/mount_python_27.py
@@ -19,7 +19,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: mount_ansible_29
+module: mount_python_27
 short_description: Control active and configured mount points
 description:
   - This module controls active and configured mount points in C(/etc/fstab).
@@ -149,7 +149,7 @@ notes:
 EXAMPLES = r'''
 # Before 2.3, option 'name' was used instead of 'path'
 - name: Mount DVD read-only
-  mount_ansible_29:
+  mount_python_27:
     path: /mnt/dvd
     src: /dev/sr0
     fstype: iso9660
@@ -157,14 +157,14 @@ EXAMPLES = r'''
     state: present
 
 - name: Mount up device by label
-  mount_ansible_29:
+  mount_python_27:
     path: /srv/disk
     src: LABEL=SOME_LABEL
     fstype: ext4
     state: present
 
 - name: Mount up device by UUID
-  mount_ansible_29:
+  mount_python_27:
     path: /home
     src: UUID=b3e48f45-f933-4c8e-a700-22a159ec9077
     fstype: xfs
@@ -172,12 +172,12 @@ EXAMPLES = r'''
     state: present
 
 - name: Unmount a mounted volume
-  mount_ansible_29:
+  mount_python_27:
     path: /tmp/mnt-pnt
     state: unmounted
 
 - name: Remount a mounted volume
-  mount_ansible_29:
+  mount_python_27:
     path: /tmp/mnt-pnt
     state: remounted
 
@@ -185,13 +185,13 @@ EXAMPLES = r'''
 # a reboot, or until calling "state: unmounted" followed by "state: mounted"
 # on the same "path"
 - name: Remount a mounted volume and append exec to the existing options
-  mount_ansible_29:
+  mount_python_27:
     path: /tmp
     state: remounted
     opts: exec
 
 - name: Mount and bind a volume
-  mount_ansible_29:
+  mount_python_27:
     path: /system/new_volume/boot
     src: /boot
     opts: bind
@@ -199,7 +199,7 @@ EXAMPLES = r'''
     fstype: none
 
 - name: Mount an NFS volume
-  mount_ansible_29:
+  mount_python_27:
     src: 192.168.1.100:/nfs/ssd/shared_data
     path: /mnt/shared_data
     opts: rw,sync,hard

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,4 +2,3 @@
 ---
 collections:
   - name: ansible.posix
-    version: '>=2.1.0,<2.2.0'

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -190,10 +190,10 @@
 #     update its view, then set up the new mounts. Otherwise,
 #     systemd will forcibly prevent mounting a new volume to an
 #     existing mount point.
-# ansible 2.9 on EL7 ships mount as a builtin module, so the bare name
-# resolves without the ansible.posix collection (which cannot be installed
-# on ansible 2.9).
-- name: Remove obsolete mounts - EL7
+# The bare module name resolves to the mount builtin on EL7 (ansible 2.9, where
+# the ansible.posix collection cannot be installed) and redirects to
+# ansible.posix.mount on newer systems.
+- name: Remove obsolete mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
     path: "{{ mount_info['path'] }}"
@@ -204,32 +204,16 @@
             selectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
-  when:
-    - __storage_is_rh_distro_7
-
-- name: Remove obsolete mounts
-  ansible.posix.mount:
-    src: "{{ mount_info['src'] | default(omit) }}"
-    path: "{{ mount_info['path'] }}"
-    fstype: "{{ mount_info['fstype'] | default(omit) }}"
-    opts: "{{ mount_info['opts'] | default(omit) }}"
-    state: "{{ mount_info['state'] }}"
-  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
-            selectattr('state', 'match', '^absent$') | list }}"
-  loop_control:
-    loop_var: mount_info
-  when:
-    - not __storage_is_rh_distro_7
 
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: true
   when: blivet_output['mounts'] | length > 0
 
-# ansible 2.9 on EL7 ships mount as a builtin module, so the bare name
-# resolves without the ansible.posix collection (which cannot be installed
-# on ansible 2.9).
-- name: Set up new/current mounts - EL7
+# The bare module name resolves to the mount builtin on EL7 (ansible 2.9, where
+# the ansible.posix collection cannot be installed) and redirects to
+# ansible.posix.mount on newer systems.
+- name: Set up new/current mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
     path: "{{ mount_info['path'] }}"
@@ -240,22 +224,6 @@
             rejectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
-  when:
-    - __storage_is_rh_distro_7
-
-- name: Set up new/current mounts
-  ansible.posix.mount:
-    src: "{{ mount_info['src'] | default(omit) }}"
-    path: "{{ mount_info['path'] }}"
-    fstype: "{{ mount_info['fstype'] | default(omit) }}"
-    opts: "{{ mount_info['opts'] | default(omit) }}"
-    state: "{{ mount_info['state'] }}"
-  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
-            rejectattr('state', 'match', '^absent$') | list }}"
-  loop_control:
-    loop_var: mount_info
-  when:
-    - not __storage_is_rh_distro_7
 
 - name: Manage mount ownership/permissions
   file:

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -205,8 +205,7 @@
   loop_control:
     loop_var: mount_info
   when:
-    - __storage_is_rh_distro
-    - ansible_facts['distribution_major_version'] == '7'
+    - __storage_is_rh_distro_7
 
 - name: Remove obsolete mounts
   ansible.posix.mount:
@@ -220,8 +219,7 @@
   loop_control:
     loop_var: mount_info
   when:
-    - not (__storage_is_rh_distro and
-        ansible_facts['distribution_major_version'] == '7')
+    - not __storage_is_rh_distro_7
 
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
@@ -243,8 +241,7 @@
   loop_control:
     loop_var: mount_info
   when:
-    - __storage_is_rh_distro
-    - ansible_facts['distribution_major_version'] == '7'
+    - __storage_is_rh_distro_7
 
 - name: Set up new/current mounts
   ansible.posix.mount:
@@ -258,8 +255,7 @@
   loop_control:
     loop_var: mount_info
   when:
-    - not (__storage_is_rh_distro and
-        ansible_facts['distribution_major_version'] == '7')
+    - not __storage_is_rh_distro_7
 
 - name: Manage mount ownership/permissions
   file:

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -190,9 +190,26 @@
 #     update its view, then set up the new mounts. Otherwise,
 #     systemd will forcibly prevent mounting a new volume to an
 #     existing mount point.
-# The bare module name resolves to the mount builtin on ansible 2.9 (where
-# the ansible.posix collection cannot be installed) and redirects to
-# ansible.posix.mount on newer systems.
+# ansible 2.9 (ansible-engine) uses the vendored mount_ansible_29 module,
+# since ansible.posix cannot be installed there; other systems use the bare
+# mount name, which redirects to the latest ansible.posix.mount.
+- name: Remove obsolete mounts - ansible 2.9
+  mount_ansible_29:
+    src: "{{ mount_info['src'] | default(omit) }}"
+    path: "{{ mount_info['path'] }}"
+    fstype: "{{ mount_info['fstype'] | default(omit) }}"
+    opts: "{{ mount_info['opts'] | default(omit) }}"
+    state: "{{ mount_info['state'] }}"
+  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
+            selectattr('state', 'match', '^absent$') | list }}"
+  loop_control:
+    loop_var: mount_info
+  when: ansible_version.full is version('2.10', '<')
+
+# Bare module name (not FQCN): on ansible 2.9 the collection is not
+# installable and an unresolvable FQCN aborts play parsing even for a task
+# skipped by "when". The bare name resolves to the ansible 2.9 builtin
+# (skipped here) and redirects to the latest collection module elsewhere.
 - name: Remove obsolete mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
@@ -204,15 +221,33 @@
             selectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
+  when: ansible_version.full is version('2.10', '>=')
 
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: true
   when: blivet_output['mounts'] | length > 0
 
-# The bare module name resolves to the mount builtin on ansible 2.9 (where
-# the ansible.posix collection cannot be installed) and redirects to
-# ansible.posix.mount on newer systems.
+# ansible 2.9 (ansible-engine) uses the vendored mount_ansible_29 module,
+# since ansible.posix cannot be installed there; other systems use the bare
+# mount name, which redirects to the latest ansible.posix.mount.
+- name: Set up new/current mounts - ansible 2.9
+  mount_ansible_29:
+    src: "{{ mount_info['src'] | default(omit) }}"
+    path: "{{ mount_info['path'] }}"
+    fstype: "{{ mount_info['fstype'] | default(omit) }}"
+    opts: "{{ mount_info['opts'] | default(omit) }}"
+    state: "{{ mount_info['state'] }}"
+  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
+            rejectattr('state', 'match', '^absent$') | list }}"
+  loop_control:
+    loop_var: mount_info
+  when: ansible_version.full is version('2.10', '<')
+
+# Bare module name (not FQCN): on ansible 2.9 the collection is not
+# installable and an unresolvable FQCN aborts play parsing even for a task
+# skipped by "when". The bare name resolves to the ansible 2.9 builtin
+# (skipped here) and redirects to the latest collection module elsewhere.
 - name: Set up new/current mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
@@ -224,6 +259,7 @@
             rejectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
+  when: ansible_version.full is version('2.10', '>=')
 
 - name: Manage mount ownership/permissions
   file:

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -190,7 +190,10 @@
 #     update its view, then set up the new mounts. Otherwise,
 #     systemd will forcibly prevent mounting a new volume to an
 #     existing mount point.
-- name: Remove obsolete mounts
+# ansible 2.9 on EL7 ships mount as a builtin module, so the bare name
+# resolves without the ansible.posix collection (which cannot be installed
+# on ansible 2.9).
+- name: Remove obsolete mounts - EL7
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
     path: "{{ mount_info['path'] }}"
@@ -201,13 +204,34 @@
             selectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
+  when:
+    - __storage_is_rh_distro
+    - ansible_facts['distribution_major_version'] == '7'
+
+- name: Remove obsolete mounts
+  ansible.posix.mount:
+    src: "{{ mount_info['src'] | default(omit) }}"
+    path: "{{ mount_info['path'] }}"
+    fstype: "{{ mount_info['fstype'] | default(omit) }}"
+    opts: "{{ mount_info['opts'] | default(omit) }}"
+    state: "{{ mount_info['state'] }}"
+  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
+            selectattr('state', 'match', '^absent$') | list }}"
+  loop_control:
+    loop_var: mount_info
+  when:
+    - not (__storage_is_rh_distro and
+        ansible_facts['distribution_major_version'] == '7')
 
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: true
   when: blivet_output['mounts'] | length > 0
 
-- name: Set up new/current mounts
+# ansible 2.9 on EL7 ships mount as a builtin module, so the bare name
+# resolves without the ansible.posix collection (which cannot be installed
+# on ansible 2.9).
+- name: Set up new/current mounts - EL7
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
     path: "{{ mount_info['path'] }}"
@@ -218,6 +242,24 @@
             rejectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
+  when:
+    - __storage_is_rh_distro
+    - ansible_facts['distribution_major_version'] == '7'
+
+- name: Set up new/current mounts
+  ansible.posix.mount:
+    src: "{{ mount_info['src'] | default(omit) }}"
+    path: "{{ mount_info['path'] }}"
+    fstype: "{{ mount_info['fstype'] | default(omit) }}"
+    opts: "{{ mount_info['opts'] | default(omit) }}"
+    state: "{{ mount_info['state'] }}"
+  loop: "{{ blivet_output.mounts | selectattr('state', 'defined') |
+            rejectattr('state', 'match', '^absent$') | list }}"
+  loop_control:
+    loop_var: mount_info
+  when:
+    - not (__storage_is_rh_distro and
+        ansible_facts['distribution_major_version'] == '7')
 
 - name: Manage mount ownership/permissions
   file:

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -190,11 +190,11 @@
 #     update its view, then set up the new mounts. Otherwise,
 #     systemd will forcibly prevent mounting a new volume to an
 #     existing mount point.
-# ansible 2.9 (ansible-engine) uses the vendored mount_ansible_29 module,
-# since ansible.posix cannot be installed there; other systems use the bare
-# mount name, which redirects to the latest ansible.posix.mount.
-- name: Remove obsolete mounts - ansible 2.9
-  mount_ansible_29:
+# On managed nodes with python 2 (EL7 with ansible 2.9, where the
+# ansible.posix collection cannot be installed), use the dependency-free
+# vendored mount_python_27 module, which retains python 2 support.
+- name: Remove obsolete mounts - python 2
+  mount_python_27:
     src: "{{ mount_info['src'] | default(omit) }}"
     path: "{{ mount_info['path'] }}"
     fstype: "{{ mount_info['fstype'] | default(omit) }}"
@@ -204,12 +204,12 @@
             selectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
-  when: ansible_version.full is version('2.10', '<')
+  when: ansible_facts['python_version'] is version('3', '<')
 
-# Bare module name (not FQCN): on ansible 2.9 the collection is not
-# installable and an unresolvable FQCN aborts play parsing even for a task
-# skipped by "when". The bare name resolves to the ansible 2.9 builtin
-# (skipped here) and redirects to the latest collection module elsewhere.
+# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+# ansible 2.9 even for a task skipped by "when", so the bare name is used.
+# This runs only on managed nodes with python 3, where the bare name resolves
+# to the latest ansible.posix.mount.
 - name: Remove obsolete mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
@@ -221,18 +221,18 @@
             selectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
-  when: ansible_version.full is version('2.10', '>=')
+  when: ansible_facts['python_version'] is version('3', '>=')
 
 - name: Tell systemd to refresh its view of /etc/fstab
   systemd:
     daemon_reload: true
   when: blivet_output['mounts'] | length > 0
 
-# ansible 2.9 (ansible-engine) uses the vendored mount_ansible_29 module,
-# since ansible.posix cannot be installed there; other systems use the bare
-# mount name, which redirects to the latest ansible.posix.mount.
-- name: Set up new/current mounts - ansible 2.9
-  mount_ansible_29:
+# On managed nodes with python 2 (EL7 with ansible 2.9, where the
+# ansible.posix collection cannot be installed), use the dependency-free
+# vendored mount_python_27 module, which retains python 2 support.
+- name: Set up new/current mounts - python 2
+  mount_python_27:
     src: "{{ mount_info['src'] | default(omit) }}"
     path: "{{ mount_info['path'] }}"
     fstype: "{{ mount_info['fstype'] | default(omit) }}"
@@ -242,12 +242,12 @@
             rejectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
-  when: ansible_version.full is version('2.10', '<')
+  when: ansible_facts['python_version'] is version('3', '<')
 
-# Bare module name (not FQCN): on ansible 2.9 the collection is not
-# installable and an unresolvable FQCN aborts play parsing even for a task
-# skipped by "when". The bare name resolves to the ansible 2.9 builtin
-# (skipped here) and redirects to the latest collection module elsewhere.
+# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+# ansible 2.9 even for a task skipped by "when", so the bare name is used.
+# This runs only on managed nodes with python 3, where the bare name resolves
+# to the latest ansible.posix.mount.
 - name: Set up new/current mounts
   mount:  # noqa fqcn
     src: "{{ mount_info['src'] | default(omit) }}"
@@ -259,7 +259,7 @@
             rejectattr('state', 'match', '^absent$') | list }}"
   loop_control:
     loop_var: mount_info
-  when: ansible_version.full is version('2.10', '>=')
+  when: ansible_facts['python_version'] is version('3', '>=')
 
 - name: Manage mount ownership/permissions
   file:

--- a/tasks/main-blivet.yml
+++ b/tasks/main-blivet.yml
@@ -190,7 +190,7 @@
 #     update its view, then set up the new mounts. Otherwise,
 #     systemd will forcibly prevent mounting a new volume to an
 #     existing mount point.
-# The bare module name resolves to the mount builtin on EL7 (ansible 2.9, where
+# The bare module name resolves to the mount builtin on ansible 2.9 (where
 # the ansible.posix collection cannot be installed) and redirects to
 # ansible.posix.mount on newer systems.
 - name: Remove obsolete mounts
@@ -210,7 +210,7 @@
     daemon_reload: true
   when: blivet_output['mounts'] | length > 0
 
-# The bare module name resolves to the mount builtin on EL7 (ansible 2.9, where
+# The bare module name resolves to the mount builtin on ansible 2.9 (where
 # the ansible.posix collection cannot be installed) and redirects to
 # ansible.posix.mount on newer systems.
 - name: Set up new/current mounts

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -45,4 +45,10 @@ __storage_is_rh_distro: "{{ ansible_facts['distribution'] in __storage_rh_distro
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
 __storage_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __storage_rh_distros_fedora }}"
+
+# Use these in conditionals to check if distro is Red Hat or clone of a specific major version
+__storage_is_rh_distro_7: "{{ __storage_is_rh_distro and ansible_facts['distribution_major_version'] == '7' }}"
+__storage_is_rh_distro_8: "{{ __storage_is_rh_distro and ansible_facts['distribution_major_version'] == '8' }}"
+__storage_is_rh_distro_9: "{{ __storage_is_rh_distro and ansible_facts['distribution_major_version'] == '9' }}"
+__storage_is_rh_distro_10: "{{ __storage_is_rh_distro and ansible_facts['distribution_major_version'] == '10' }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,8 @@ __storage_required_facts:
   - distribution_version
   - os_family
   - pkg_mgr
+  # provides ansible_facts.python_version, used to pick the mount module
+  - python_version
 
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of


### PR DESCRIPTION
Enhancement: Select the `mount` module by the managed node's python version instead of the ansible version. Gate the two mount tasks (remove obsolete mounts, set up new/current mounts) on `ansible_facts.python_version`: use the dependency-free vendored `mount_python_27` module on python 2 managed nodes, and the bare `mount` name (redirecting to `ansible.posix.mount`) on python 3. Rename the vendored module from `mount_ansible_29` to `mount_python_27`, gather the `python_version` fact subset, and drop the `ansible.posix` collection-requirements version cap.

Reason: On EL7 (ansible 2.9, python 2) the `ansible.posix` collection cannot be installed, so a vendored mount module that retains python 2 support is needed. The managed node's python version - not the controller's ansible version - is the accurate discriminator for which module can run. A fully-qualified `ansible.posix.mount` would abort play parsing on ansible 2.9 even when skipped, so the bare name is used on python 3.

Result: The role manages mounts with the vendored `mount_python_27` module on python 2 managed nodes (e.g. EL7) and the latest `ansible.posix.mount` everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount management across supported Python versions, including Python 2 environments.
  * Improved compatibility for Red Hat-based systems spanning versions 7 through 10.
  * Added reliable handling for mounting, unmounting, remounting, and `/etc/fstab` updates, including rollback on failures.
* **Chores**
  * Removed the version restriction for the POSIX collection dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->