### PR TITLE
ci: tell flake8 to ignore copied mount_python_27.py

### DIFF
--- a/library/mount_python_27.py
+++ b/library/mount_python_27.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# flake8 does not like this file
+# flake8: noqa
 
 # Copyright: (c) 2012, Red Hat, inc
 # Written by Seth Vidal


### PR DESCRIPTION
flake8 does not like this file.  Since it is just a copy
from elsewhere, tell flake8 to ignore it.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration for a bundled compatibility module.
  * No user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->